### PR TITLE
Naver 로그인 추가

### DIFF
--- a/src/main/java/haru/harudongseon/global/oauth/GoogleOAuth2UserInfo.java
+++ b/src/main/java/haru/harudongseon/global/oauth/GoogleOAuth2UserInfo.java
@@ -24,8 +24,8 @@ public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
     }
 
     @Override
-    public Long getOauthId() {
-        return (Long) attributes.get("id");
+    public String getOauthId() {
+        return (String) attributes.get("id");
     }
 
     public LoginType getOauthType() { return LoginType.GOOGLE; }

--- a/src/main/java/haru/harudongseon/global/oauth/KakaoOAuth2UserInfo.java
+++ b/src/main/java/haru/harudongseon/global/oauth/KakaoOAuth2UserInfo.java
@@ -29,8 +29,8 @@ public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
     }
 
     @Override
-    public Long getOauthId() {
-        return (Long) attributes.get("id");
+    public String getOauthId() {
+        return (String) attributes.get("id");
     }
 
     public LoginType getOauthType() { return LoginType.KAKAO; }

--- a/src/main/java/haru/harudongseon/global/oauth/NaverOAuth2UserInfo.java
+++ b/src/main/java/haru/harudongseon/global/oauth/NaverOAuth2UserInfo.java
@@ -27,9 +27,9 @@ public class NaverOAuth2UserInfo extends OAuth2UserInfo {
     }
 
     @Override
-    public Long getOauthId() {
+    public String getOauthId() {
         final Map<String, Object> response = (Map<String, Object>) attributes.get("response");
-        return (Long) response.get("id");
+        return (String) response.get("id");
     }
 
     public LoginType getOauthType() { return LoginType.NAVER; }

--- a/src/main/java/haru/harudongseon/global/oauth/OAuth2UserInfo.java
+++ b/src/main/java/haru/harudongseon/global/oauth/OAuth2UserInfo.java
@@ -13,6 +13,6 @@ public abstract class OAuth2UserInfo {
     public abstract String getEmail();
     public abstract String getNickname();
     public abstract String getProfileUrl();
-    public abstract Long getOauthId();
+    public abstract String getOauthId();
     public abstract LoginType getOauthType();
 }

--- a/src/main/java/haru/harudongseon/global/oauth/application/OauthClientService.java
+++ b/src/main/java/haru/harudongseon/global/oauth/application/OauthClientService.java
@@ -22,6 +22,9 @@ public class OauthClientService {
     @Value("${oauth2.provider.google.user-info-uri}")
     private String googleUserInfoUri;
 
+    @Value("${oauth2.provider.naver.user-info-uri}")
+    private String naverUserInfoUri;
+
     private final RestTemplate restTemplate;
 
 
@@ -50,6 +53,17 @@ public class OauthClientService {
 
         final Map<String, Object> attributes = response.getBody();
         final OAuthAttributes oAuthAttributes = OAuthAttributes.of(LoginType.GOOGLE, attributes);
+        return oAuthAttributes.getOAuth2UserInfo();
+    }
+
+    public OAuth2UserInfo getNaverUserInfo(final String oauthToken) {
+        final HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.set(HttpHeaders.AUTHORIZATION, JWT_PREFIX + oauthToken);
+        final HttpEntity<String> request = new HttpEntity<>(httpHeaders);
+        final ResponseEntity<Map> response = restTemplate.exchange(naverUserInfoUri, HttpMethod.GET, request, Map.class);
+
+        final Map<String, Object> attributes = response.getBody();
+        final OAuthAttributes oAuthAttributes = OAuthAttributes.of(LoginType.NAVER, attributes);
         return oAuthAttributes.getOAuth2UserInfo();
     }
 }

--- a/src/main/java/haru/harudongseon/member/application/LoginService.java
+++ b/src/main/java/haru/harudongseon/member/application/LoginService.java
@@ -46,7 +46,7 @@ public class LoginService {
     }
 
     private String createAccessTokenByMemberPresent(final OAuth2UserInfo oauth2UserInfo, final String deviceId) {
-        final Long oauthId = oauth2UserInfo.getOauthId();
+        final String oauthId = oauth2UserInfo.getOauthId();
         final LoginType oauthType = oauth2UserInfo.getOauthType();
         final Optional<Member> optionalMember = memberRepository.findByOauthIdAndLoginType(oauthId, oauthType);
 

--- a/src/main/java/haru/harudongseon/member/application/LoginService.java
+++ b/src/main/java/haru/harudongseon/member/application/LoginService.java
@@ -7,6 +7,7 @@ import haru.harudongseon.global.oauth.LoginType;
 import haru.harudongseon.global.oauth.OAuth2UserInfo;
 import haru.harudongseon.global.oauth.application.OauthClientService;
 import haru.harudongseon.member.application.dto.OauthLoginRequest;
+import haru.harudongseon.member.application.dto.OauthLoginResponse;
 import haru.harudongseon.member.domain.Member;
 import haru.harudongseon.member.domain.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,22 +25,22 @@ public class LoginService {
 
     // TODO : 로그인 시 생성한 Access Token 어떻게 내려줄지 프론트와 논의 (우선 String 그대로 Access 토큰 반환)
     // TODO : Refresh Token도 추후에 생각
-    public String oauthLogin(final OauthLoginRequest request) {
+    public OauthLoginResponse oauthLogin(final OauthLoginRequest request) {
         final String loginType = request.loginType();
         final String token = request.token();
         final String deviceId = request.deviceId();
 
         if (loginType.equals("kakao")) {
             final OAuth2UserInfo kakaoUserInfo = oauthClientService.getKakaoUserInfo(token);
-            return createAccessTokenByMemberPresent(kakaoUserInfo, deviceId);
+            return new OauthLoginResponse(createAccessTokenByMemberPresent(kakaoUserInfo, deviceId));
         }
         if (loginType.equals("google")) {
             final OAuth2UserInfo googleUserInfo = oauthClientService.getGoogleUserInfo(token);
-            return createAccessTokenByMemberPresent(googleUserInfo, deviceId);
+            return new OauthLoginResponse(createAccessTokenByMemberPresent(googleUserInfo, deviceId));
         }
         if (loginType.equals("naver")) {
             final OAuth2UserInfo naverUserInfo = oauthClientService.getNaverUserInfo(token);
-            return createAccessTokenByMemberPresent(naverUserInfo, deviceId);
+            return new OauthLoginResponse(createAccessTokenByMemberPresent(naverUserInfo, deviceId));
         }
 
         return null;

--- a/src/main/java/haru/harudongseon/member/application/LoginService.java
+++ b/src/main/java/haru/harudongseon/member/application/LoginService.java
@@ -37,6 +37,10 @@ public class LoginService {
             final OAuth2UserInfo googleUserInfo = oauthClientService.getGoogleUserInfo(token);
             return createAccessTokenByMemberPresent(googleUserInfo, deviceId);
         }
+        if (loginType.equals("naver")) {
+            final OAuth2UserInfo naverUserInfo = oauthClientService.getNaverUserInfo(token);
+            return createAccessTokenByMemberPresent(naverUserInfo, deviceId);
+        }
 
         return null;
     }

--- a/src/main/java/haru/harudongseon/member/application/dto/OauthLoginResponse.java
+++ b/src/main/java/haru/harudongseon/member/application/dto/OauthLoginResponse.java
@@ -1,10 +1,4 @@
 package haru.harudongseon.member.application.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-
-@Data
-@AllArgsConstructor
-public class OauthLoginResponse {
-    private String accessToken;
+public record OauthLoginResponse(String accessToken) {
 }

--- a/src/main/java/haru/harudongseon/member/application/dto/OauthLoginResponse.java
+++ b/src/main/java/haru/harudongseon/member/application/dto/OauthLoginResponse.java
@@ -1,0 +1,10 @@
+package haru.harudongseon.member.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class OauthLoginResponse {
+    private String accessToken;
+}

--- a/src/main/java/haru/harudongseon/member/domain/Member.java
+++ b/src/main/java/haru/harudongseon/member/domain/Member.java
@@ -21,7 +21,7 @@ public class Member extends BaseEntity {
 
     private String profileUrl;
 
-    private Long oauthId;
+    private String oauthId;
 
     private String deviceId;
 
@@ -29,7 +29,7 @@ public class Member extends BaseEntity {
     private LoginType loginType;
 
     public Member(final String email, final String nickname,
-                  final String profileUrl, final Long oauthId,
+                  final String profileUrl, final String oauthId,
                   final String deviceId, final LoginType loginType) {
         this.email = email;
         this.nickname = nickname;

--- a/src/main/java/haru/harudongseon/member/domain/MemberRepository.java
+++ b/src/main/java/haru/harudongseon/member/domain/MemberRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findByOauthIdAndLoginType(final Long oauthId, final LoginType loginType);
+    Optional<Member> findByOauthIdAndLoginType(final String oauthId, final LoginType loginType);
 }

--- a/src/main/java/haru/harudongseon/member/presentation/LoginController.java
+++ b/src/main/java/haru/harudongseon/member/presentation/LoginController.java
@@ -18,7 +18,7 @@ public class LoginController {
     // TODO : 로그인 시 생성한 Access Token 어떻게 내려줄지 프론트와 논의 (우선 String 그대로 Access 토큰 반환)
     @PostMapping("/oauth-login")
     public ResponseEntity<OauthLoginResponse> memberLogin(@RequestBody final OauthLoginRequest oauthLoginRequest) {
-        final String accessToken = loginService.oauthLogin(oauthLoginRequest);
-        return ResponseEntity.ok(new OauthLoginResponse(accessToken));
+        final OauthLoginResponse loginResponse = loginService.oauthLogin(oauthLoginRequest);
+        return ResponseEntity.ok(loginResponse);
     }
 }

--- a/src/main/java/haru/harudongseon/member/presentation/LoginController.java
+++ b/src/main/java/haru/harudongseon/member/presentation/LoginController.java
@@ -1,7 +1,7 @@
 package haru.harudongseon.member.presentation;
 
 import haru.harudongseon.member.application.LoginService;
-import haru.harudongseon.member.application.dto.LoginRequest;
+import haru.harudongseon.member.application.dto.OauthLoginResponse;
 import haru.harudongseon.member.application.dto.OauthLoginRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,8 +17,8 @@ public class LoginController {
 
     // TODO : 로그인 시 생성한 Access Token 어떻게 내려줄지 프론트와 논의 (우선 String 그대로 Access 토큰 반환)
     @PostMapping("/oauth-login")
-    public ResponseEntity<String> memberLogin(@RequestBody final OauthLoginRequest oauthLoginRequest) {
+    public ResponseEntity<OauthLoginResponse> memberLogin(@RequestBody final OauthLoginRequest oauthLoginRequest) {
         final String accessToken = loginService.oauthLogin(oauthLoginRequest);
-        return ResponseEntity.ok(accessToken);
+        return ResponseEntity.ok(new OauthLoginResponse(accessToken));
     }
 }


### PR DESCRIPTION
## 🔥 연관 이슈

- close #1 

## 🚀 작업 내용

+ Naver Oauth2 연동

+ oauthId 타입 변경

+ 토큰 응답 형식 변경


## 💬 리뷰 중점사항

+ `oauthId`
  + 네이버의 경우 문자열이 섞인 값으로 넘어와 `Long -> String`으로 수정했습니다.

+ 로그인 응답값 형식 수정
  + 기존에는 access token 값만 반환되는데 객체로 한번 감싸서 주는게 좋을 것 같아 dto 추가하였습니다.