### PR TITLE
로그인 기능 리팩토링 & 예외 전역처리 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
     implementation 'com.auth0:java-jwt:4.4.0'

--- a/src/main/java/haru/harudongseon/global/exception/ErrorResponse.java
+++ b/src/main/java/haru/harudongseon/global/exception/ErrorResponse.java
@@ -1,0 +1,4 @@
+package haru.harudongseon.global.exception;
+
+public record ErrorResponse(String errorMessage) {
+}

--- a/src/main/java/haru/harudongseon/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/haru/harudongseon/global/exception/GlobalExceptionHandler.java
@@ -51,4 +51,15 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(new ErrorResponse(defaultErrorMessage));
     }
+
+    @ExceptionHandler(value = {
+            IllegalArgumentException.class
+    })
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(final IllegalArgumentException exception) {
+        final String errorMessage = exception.getMessage();
+        log.warn(errorMessage);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(errorMessage));
+    }
 }

--- a/src/main/java/haru/harudongseon/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/haru/harudongseon/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,54 @@
+package haru.harudongseon.global.exception;
+
+import java.util.Random;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    private static final int ERROR_KEY_LENGTH = 5;
+    private static final Random random = new Random();
+    private static final String GENERATE_CHARS = "abcdefghijklmnopqrstuvwxyz";
+    private static final String DEFAULT_ERROR_MESSAGE = "관리자에게 문의하세요. ";
+
+    @ExceptionHandler(value = {
+            RuntimeException.class
+    })
+    public ResponseEntity<ErrorResponse> handleRuntimeException(final RuntimeException exception) {
+        final String message = exception.getMessage();
+
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < ERROR_KEY_LENGTH; i++) {
+            sb.append(GENERATE_CHARS.charAt(random.nextInt(GENERATE_CHARS.length())));
+        }
+        final String logErrorKeyInfo = String.format("%n error key : %s", sb);
+        final String exceptionTypeInfo = String.format("%n class type : %s", exception.getClass());
+
+        log.error(message + logErrorKeyInfo + exceptionTypeInfo);
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse(DEFAULT_ERROR_MESSAGE + String.format("error key : %s", sb)));
+    }
+
+
+    @ExceptionHandler(value = {
+            MethodArgumentNotValidException.class
+    })
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(final MethodArgumentNotValidException exception) {
+        final ObjectError errorTarget = exception.getAllErrors().get(0);
+        final String defaultErrorMessage = errorTarget.getDefaultMessage();
+        final String objectName = errorTarget.getObjectName();
+        log.warn("Request Field Error - Message: {}, Target : {}", defaultErrorMessage, objectName);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(defaultErrorMessage));
+    }
+}

--- a/src/main/java/haru/harudongseon/global/oauth/application/OauthClientService.java
+++ b/src/main/java/haru/harudongseon/global/oauth/application/OauthClientService.java
@@ -61,9 +61,9 @@ public class OauthClientService {
         return request;
     }
 
-    private OAuth2UserInfo generateOAuth2UserInfo(final ResponseEntity<Map> response, final LoginType naver) {
+    private OAuth2UserInfo generateOAuth2UserInfo(final ResponseEntity<Map> response, final LoginType loginType) {
         final Map<String, Object> attributes = response.getBody();
-        final OAuthAttributes oAuthAttributes = OAuthAttributes.of(naver, attributes);
+        final OAuthAttributes oAuthAttributes = OAuthAttributes.of(loginType, attributes);
         return oAuthAttributes.getOAuth2UserInfo();
     }
 }

--- a/src/main/java/haru/harudongseon/global/oauth/application/OauthClientService.java
+++ b/src/main/java/haru/harudongseon/global/oauth/application/OauthClientService.java
@@ -33,37 +33,37 @@ public class OauthClientService {
     }
 
     public OAuth2UserInfo getKakaoUserInfo(final String oauthToken) {
+        final HttpEntity<String> request = generateRequest(oauthToken);
+        final ResponseEntity<Map> response = restTemplate.exchange(kakaoUserInfoUri, HttpMethod.GET, request, Map.class);
+
+        return generateOAuth2UserInfo(response, LoginType.KAKAO);
+    }
+
+    public OAuth2UserInfo getGoogleUserInfo(final String oauthToken) {
+        final HttpEntity<String> request = generateRequest(oauthToken);
+        final ResponseEntity<Map> response = restTemplate.exchange(googleUserInfoUri, HttpMethod.GET, request, Map.class);
+
+        return generateOAuth2UserInfo(response, LoginType.GOOGLE);
+    }
+
+    public OAuth2UserInfo getNaverUserInfo(final String oauthToken) {
+        final HttpEntity<String> request = generateRequest(oauthToken);
+        final ResponseEntity<Map> response = restTemplate.exchange(naverUserInfoUri, HttpMethod.GET, request, Map.class);
+
+        return generateOAuth2UserInfo(response, LoginType.NAVER);
+    }
+
+    private HttpEntity<String> generateRequest(final String oauthToken) {
         final HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.set(HttpHeaders.AUTHORIZATION, JWT_PREFIX + oauthToken);
         httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         final HttpEntity<String> request = new HttpEntity<>(httpHeaders);
-        final ResponseEntity<Map> response = restTemplate.exchange(kakaoUserInfoUri, HttpMethod.GET, request, Map.class);
-
-        final Map<String, Object> attributes = response.getBody();
-
-        final OAuthAttributes oAuthAttributes = OAuthAttributes.of(LoginType.KAKAO, attributes);
-        return oAuthAttributes.getOAuth2UserInfo();
+        return request;
     }
 
-    public OAuth2UserInfo getGoogleUserInfo(final String oauthToken) {
-        final HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.set(HttpHeaders.AUTHORIZATION, JWT_PREFIX + oauthToken);
-        final HttpEntity<String> request = new HttpEntity<>(httpHeaders);
-        final ResponseEntity<Map> response = restTemplate.exchange(googleUserInfoUri, HttpMethod.GET, request, Map.class);
-
+    private OAuth2UserInfo generateOAuth2UserInfo(final ResponseEntity<Map> response, final LoginType naver) {
         final Map<String, Object> attributes = response.getBody();
-        final OAuthAttributes oAuthAttributes = OAuthAttributes.of(LoginType.GOOGLE, attributes);
-        return oAuthAttributes.getOAuth2UserInfo();
-    }
-
-    public OAuth2UserInfo getNaverUserInfo(final String oauthToken) {
-        final HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.set(HttpHeaders.AUTHORIZATION, JWT_PREFIX + oauthToken);
-        final HttpEntity<String> request = new HttpEntity<>(httpHeaders);
-        final ResponseEntity<Map> response = restTemplate.exchange(naverUserInfoUri, HttpMethod.GET, request, Map.class);
-
-        final Map<String, Object> attributes = response.getBody();
-        final OAuthAttributes oAuthAttributes = OAuthAttributes.of(LoginType.NAVER, attributes);
+        final OAuthAttributes oAuthAttributes = OAuthAttributes.of(naver, attributes);
         return oAuthAttributes.getOAuth2UserInfo();
     }
 }

--- a/src/main/java/haru/harudongseon/member/application/LoginService.java
+++ b/src/main/java/haru/harudongseon/member/application/LoginService.java
@@ -37,9 +37,11 @@ public class LoginService {
             final OAuth2UserInfo naverUserInfo = oauthClientService.getNaverUserInfo(token);
             return createResponseByMemberPresent(naverUserInfo, deviceId);
         }
-
-        final OAuth2UserInfo googleUserInfo = oauthClientService.getGoogleUserInfo(token);
-        return createResponseByMemberPresent(googleUserInfo, deviceId);
+        if (loginType.equals("google")) {
+            final OAuth2UserInfo googleUserInfo = oauthClientService.getGoogleUserInfo(token);
+            return createResponseByMemberPresent(googleUserInfo, deviceId);
+        }
+        throw new IllegalArgumentException("OAuth 타입이 적절하지 않습니다.");
     }
 
     private OauthLoginResponse createResponseByMemberPresent(final OAuth2UserInfo oauth2UserInfo, final String deviceId) {

--- a/src/main/java/haru/harudongseon/member/application/LoginService.java
+++ b/src/main/java/haru/harudongseon/member/application/LoginService.java
@@ -23,8 +23,7 @@ public class LoginService {
     private final JwtService jwtService;
     private final MemberRepository memberRepository;
 
-    // TODO : 로그인 시 생성한 Access Token 어떻게 내려줄지 프론트와 논의 (우선 String 그대로 Access 토큰 반환)
-    // TODO : Refresh Token도 추후에 생각
+    // TODO : Refresh Token는 추후에 생각
     public OauthLoginResponse oauthLogin(final OauthLoginRequest request) {
         final String loginType = request.loginType();
         final String token = request.token();
@@ -32,21 +31,18 @@ public class LoginService {
 
         if (loginType.equals("kakao")) {
             final OAuth2UserInfo kakaoUserInfo = oauthClientService.getKakaoUserInfo(token);
-            return new OauthLoginResponse(createAccessTokenByMemberPresent(kakaoUserInfo, deviceId));
-        }
-        if (loginType.equals("google")) {
-            final OAuth2UserInfo googleUserInfo = oauthClientService.getGoogleUserInfo(token);
-            return new OauthLoginResponse(createAccessTokenByMemberPresent(googleUserInfo, deviceId));
+            return createResponseByMemberPresent(kakaoUserInfo, deviceId);
         }
         if (loginType.equals("naver")) {
             final OAuth2UserInfo naverUserInfo = oauthClientService.getNaverUserInfo(token);
-            return new OauthLoginResponse(createAccessTokenByMemberPresent(naverUserInfo, deviceId));
+            return createResponseByMemberPresent(naverUserInfo, deviceId);
         }
 
-        return null;
+        final OAuth2UserInfo googleUserInfo = oauthClientService.getGoogleUserInfo(token);
+        return createResponseByMemberPresent(googleUserInfo, deviceId);
     }
 
-    private String createAccessTokenByMemberPresent(final OAuth2UserInfo oauth2UserInfo, final String deviceId) {
+    private OauthLoginResponse createResponseByMemberPresent(final OAuth2UserInfo oauth2UserInfo, final String deviceId) {
         final String oauthId = oauth2UserInfo.getOauthId();
         final LoginType oauthType = oauth2UserInfo.getOauthType();
         final Optional<Member> optionalMember = memberRepository.findByOauthIdAndLoginType(oauthId, oauthType);
@@ -58,10 +54,12 @@ public class LoginService {
             final Member member = new Member(email, nickname, profileUrl, oauthId, deviceId, oauthType);
             final Member savedMember = memberRepository.save(member);
 
-            return jwtService.createAccessToken(savedMember.getId());
+            final String accessToken = jwtService.createAccessToken(savedMember.getId());
+            return new OauthLoginResponse(accessToken, true);
         }
 
         final Member findMember = optionalMember.get();
-        return jwtService.createAccessToken(findMember.getId());
+        final String accessToken = jwtService.createAccessToken(findMember.getId());
+        return new OauthLoginResponse(accessToken, false);
     }
 }

--- a/src/main/java/haru/harudongseon/member/application/dto/OauthLoginRequest.java
+++ b/src/main/java/haru/harudongseon/member/application/dto/OauthLoginRequest.java
@@ -1,4 +1,13 @@
 package haru.harudongseon.member.application.dto;
 
-public record OauthLoginRequest(String loginType, String token, String deviceId) {
+import jakarta.validation.constraints.NotBlank;
+
+public record OauthLoginRequest(
+        @NotBlank(message = "로그인 타입은 공백일 수 없습니다.")
+        String loginType,
+        @NotBlank(message = "OAuth 인증 토큰은 공백일 수 없습니다.")
+        String token,
+        @NotBlank(message = "Device ID는 공백일 수 없습니다.")
+        String deviceId
+) {
 }

--- a/src/main/java/haru/harudongseon/member/application/dto/OauthLoginResponse.java
+++ b/src/main/java/haru/harudongseon/member/application/dto/OauthLoginResponse.java
@@ -1,4 +1,4 @@
 package haru.harudongseon.member.application.dto;
 
-public record OauthLoginResponse(String accessToken) {
+public record OauthLoginResponse(String accessToken, Boolean isNewMember) {
 }

--- a/src/main/java/haru/harudongseon/member/presentation/LoginController.java
+++ b/src/main/java/haru/harudongseon/member/presentation/LoginController.java
@@ -3,6 +3,7 @@ package haru.harudongseon.member.presentation;
 import haru.harudongseon.member.application.LoginService;
 import haru.harudongseon.member.application.dto.OauthLoginResponse;
 import haru.harudongseon.member.application.dto.OauthLoginRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,7 +17,7 @@ public class LoginController {
     private final LoginService loginService;
 
     @PostMapping("/oauth-login")
-    public ResponseEntity<OauthLoginResponse> memberLogin(@RequestBody final OauthLoginRequest oauthLoginRequest) {
+    public ResponseEntity<OauthLoginResponse> memberLogin(@Valid @RequestBody final OauthLoginRequest oauthLoginRequest) {
         final OauthLoginResponse loginResponse = loginService.oauthLogin(oauthLoginRequest);
         return ResponseEntity.ok(loginResponse);
     }

--- a/src/main/java/haru/harudongseon/member/presentation/LoginController.java
+++ b/src/main/java/haru/harudongseon/member/presentation/LoginController.java
@@ -15,7 +15,6 @@ public class LoginController {
 
     private final LoginService loginService;
 
-    // TODO : 로그인 시 생성한 Access Token 어떻게 내려줄지 프론트와 논의 (우선 String 그대로 Access 토큰 반환)
     @PostMapping("/oauth-login")
     public ResponseEntity<OauthLoginResponse> memberLogin(@RequestBody final OauthLoginRequest oauthLoginRequest) {
         final OauthLoginResponse loginResponse = loginService.oauthLogin(oauthLoginRequest);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,5 @@
 spring:
+
   security:
     oauth2:
       client:
@@ -31,3 +32,6 @@ spring:
 
           google:
             user-info-uri: ${oauth2.provider.google.user-info.uri}
+  h2:
+    console:
+      enabled: true


### PR DESCRIPTION
## 🔥 연관 이슈

- close #9
- close #8 

## 🚀 작업 내용

### 기존 로그인 로직에서 다음 작업 리팩토링
* accessToken만 존재하던OauthLoginResponse에 신규회원인지 아닌지 판단하는 플래그 필드 isNewMember 추가
* 서비스에서 oauthId로 Member 조회 후 신규 회원 플래그 필드 값 결정
  * 기존에 있던 분기에서 AccessToken 리턴하던 것 -> 신규 회원 플래그 값 추가해서 Response 리턴하도록 리팩토링 

### 예외 전역 처리 구현
* ErrorResponseDto 구현
```
{
    "errorMessage" : {errorMessage}
}
```
  * global 패키지에 구현
  * 로그인 관련 예외들 `@ExceptionHandler`를 통해 전역 처리
    * Request Field에 값이 들어오지 않는 예외 `@NotBlank`로 Validation하여 `MethodArgumentNotValidException` 예외 처리
      * Status Code : 400 
      * 로그 : 메시지 + 타겟 / Response : 메시지만  
    * 특정 예외가 아닌 `RuntimeException`
      * Status Code : 500
      * 랜덤 Error Key를 생성하고, Response에는 Error Key만 담고 로그에 Error key와 구체적인 에러 내용을 담음 (클라이언트, 사용자에게는 구체적인 에러를 감추고 에러 키로 로그를 추적하여 에러 확인하기 위함) 

<br>

++ 추가적으로 로그인 테스트는 이슈로 생성해놓고 추후에 보강하도록 하겠습니다!


## 💬 리뷰 중점사항

그때 같이 말한 Flow가 맞게 구현됐는지 봐주시면 감사하겠습니다!
혹시 놓친 부분이 있거나 수정 할 부분이 있다면 바로 코멘트 남겨주세요!

