### PR TITLE
내 정보 수정/조회 API 구현 & Swagger 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.rest-assured:rest-assured:5.4.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
     implementation 'com.auth0:java-jwt:4.4.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/haru/harudongseon/global/configuration/MvcConfiguration.java
+++ b/src/main/java/haru/harudongseon/global/configuration/MvcConfiguration.java
@@ -1,7 +1,8 @@
-package haru.harudongseon.global.mvc;
+package haru.harudongseon.global.configuration;
 
 import java.util.List;
 
+import haru.harudongseon.global.mvc.MemberArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;

--- a/src/main/java/haru/harudongseon/global/configuration/SwaggerConfig.java
+++ b/src/main/java/haru/harudongseon/global/configuration/SwaggerConfig.java
@@ -1,0 +1,41 @@
+package haru.harudongseon.global.configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = "하루 동선 Application API 명세서",
+                description = "하루 동선 Application API 명세서",
+                version = "v1"
+        )
+)
+@Configuration
+public class SwaggerConfig {
+
+    private static final String TOKEN_PREFIX = "Bearer";
+
+    @Bean
+    public OpenAPI openAPI() {
+        final String securityName = "JWT";
+        final SecurityRequirement securityRequirement = new SecurityRequirement().addList(securityName);
+        final SecurityScheme securityScheme = new SecurityScheme()
+                .name(securityName)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme(TOKEN_PREFIX)
+                .bearerFormat(securityName);
+
+        final Components components = new Components()
+                .addSecuritySchemes(securityName, securityScheme);
+
+        return new OpenAPI()
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}

--- a/src/main/java/haru/harudongseon/global/exception/ErrorResponse.java
+++ b/src/main/java/haru/harudongseon/global/exception/ErrorResponse.java
@@ -1,4 +1,9 @@
 package haru.harudongseon.global.exception;
 
-public record ErrorResponse(String errorMessage) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ErrorResponse(
+        @Schema(description = "에러 Response", nullable = false, example = "에러 메시지")
+        String errorMessage
+) {
 }

--- a/src/main/java/haru/harudongseon/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/haru/harudongseon/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package haru.harudongseon.global.exception;
 
 import java.util.Random;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -60,6 +61,17 @@ public class GlobalExceptionHandler {
         log.warn(errorMessage);
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(errorMessage));
+    }
+
+    @ExceptionHandler(value = {
+            EntityNotFoundException.class
+    })
+    public ResponseEntity<ErrorResponse> handleNotFoundException(final RuntimeException exception) {
+        final String errorMessage = exception.getMessage();
+        log.warn(errorMessage);
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(new ErrorResponse(errorMessage));
     }
 }

--- a/src/main/java/haru/harudongseon/global/jwt/JwtService.java
+++ b/src/main/java/haru/harudongseon/global/jwt/JwtService.java
@@ -43,6 +43,10 @@ public class JwtService {
                 .sign(Algorithm.HMAC512(secretKey));
     }
 
+    public Long extractMemberId(final String token) {
+        return JWT.decode(token).getClaim(MEMBER_ID_CLAIM).asLong();
+    }
+
     public TokenStatus validateToken(final String token) {
         try {
             JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);

--- a/src/main/java/haru/harudongseon/global/mvc/AuthMemberDto.java
+++ b/src/main/java/haru/harudongseon/global/mvc/AuthMemberDto.java
@@ -1,0 +1,4 @@
+package haru.harudongseon.global.mvc;
+
+public record AuthMemberDto(Long memberId) {
+}

--- a/src/main/java/haru/harudongseon/global/mvc/AuthPrincipal.java
+++ b/src/main/java/haru/harudongseon/global/mvc/AuthPrincipal.java
@@ -1,0 +1,11 @@
+package haru.harudongseon.global.mvc;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(value = ElementType.PARAMETER)
+public @interface AuthPrincipal {
+}

--- a/src/main/java/haru/harudongseon/global/mvc/MemberArgumentResolver.java
+++ b/src/main/java/haru/harudongseon/global/mvc/MemberArgumentResolver.java
@@ -1,0 +1,35 @@
+package haru.harudongseon.global.mvc;
+
+import haru.harudongseon.global.jwt.JwtService;
+import haru.harudongseon.member.domain.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class MemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String JWT_PREFIX = "Bearer ";
+
+    private final JwtService jwtService;
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthPrincipal.class);
+    }
+
+    @Override
+    public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer, final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) throws Exception {
+        final String authHeaderValue = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
+        final String accessToken = authHeaderValue.replace(JWT_PREFIX, "");
+        final Long memberId = jwtService.extractMemberId(accessToken);
+
+        return new AuthMemberDto(memberId);
+    }
+}

--- a/src/main/java/haru/harudongseon/global/mvc/MvcConfiguration.java
+++ b/src/main/java/haru/harudongseon/global/mvc/MvcConfiguration.java
@@ -1,0 +1,20 @@
+package haru.harudongseon.global.mvc;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class MvcConfiguration implements WebMvcConfigurer {
+
+    private final MemberArgumentResolver memberArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(memberArgumentResolver);
+    }
+}

--- a/src/main/java/haru/harudongseon/global/oauth/GoogleOAuth2UserInfo.java
+++ b/src/main/java/haru/harudongseon/global/oauth/GoogleOAuth2UserInfo.java
@@ -19,7 +19,7 @@ public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
     }
 
     @Override
-    public String getProfileUrl() {
+    public String getProfileImageUrl() {
         return (String) attributes.get("picture");
     }
 

--- a/src/main/java/haru/harudongseon/global/oauth/KakaoOAuth2UserInfo.java
+++ b/src/main/java/haru/harudongseon/global/oauth/KakaoOAuth2UserInfo.java
@@ -22,7 +22,7 @@ public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
     }
 
     @Override
-    public String getProfileUrl() {
+    public String getProfileImageUrl() {
         final Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
         final Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
         return (String) profile.get("profile_image_url");

--- a/src/main/java/haru/harudongseon/global/oauth/NaverOAuth2UserInfo.java
+++ b/src/main/java/haru/harudongseon/global/oauth/NaverOAuth2UserInfo.java
@@ -21,7 +21,7 @@ public class NaverOAuth2UserInfo extends OAuth2UserInfo {
     }
 
     @Override
-    public String getProfileUrl() {
+    public String getProfileImageUrl() {
         final Map<String, Object> response = (Map<String, Object>) attributes.get("response");
         return (String) response.get("profile_image");
     }

--- a/src/main/java/haru/harudongseon/global/oauth/OAuth2UserInfo.java
+++ b/src/main/java/haru/harudongseon/global/oauth/OAuth2UserInfo.java
@@ -12,7 +12,7 @@ public abstract class OAuth2UserInfo {
 
     public abstract String getEmail();
     public abstract String getNickname();
-    public abstract String getProfileUrl();
+    public abstract String getProfileImageUrl();
     public abstract String getOauthId();
     public abstract LoginType getOauthType();
 }

--- a/src/main/java/haru/harudongseon/member/application/LoginService.java
+++ b/src/main/java/haru/harudongseon/member/application/LoginService.java
@@ -52,7 +52,7 @@ public class LoginService {
         if (optionalMember.isEmpty()) {
             final String email = oauth2UserInfo.getEmail();
             final String nickname = oauth2UserInfo.getNickname();
-            final String profileUrl = oauth2UserInfo.getProfileUrl();
+            final String profileUrl = oauth2UserInfo.getProfileImageUrl();
             final Member member = new Member(email, nickname, profileUrl, oauthId, deviceId, oauthType);
             final Member savedMember = memberRepository.save(member);
 

--- a/src/main/java/haru/harudongseon/member/application/MemberService.java
+++ b/src/main/java/haru/harudongseon/member/application/MemberService.java
@@ -1,0 +1,28 @@
+package haru.harudongseon.member.application;
+
+import haru.harudongseon.member.application.dto.MyInfoResponse;
+import haru.harudongseon.member.domain.Member;
+import haru.harudongseon.member.domain.MemberRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public MyInfoResponse findMyInfo(Long memberId) {
+        final Member findMember = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("해당하는 멤버를 찾을 수 없습니다."));
+
+        final String email = findMember.getEmail();
+        final String nickname = findMember.getNickname();
+        final String profileUrl = findMember.getProfileUrl();
+        return new MyInfoResponse(email, nickname, profileUrl);
+    }
+}

--- a/src/main/java/haru/harudongseon/member/application/MemberService.java
+++ b/src/main/java/haru/harudongseon/member/application/MemberService.java
@@ -22,7 +22,7 @@ public class MemberService {
 
         final String email = findMember.getEmail();
         final String nickname = findMember.getNickname();
-        final String profileUrl = findMember.getProfileUrl();
-        return new MyProfileResponse(email, nickname, profileUrl);
+        final String profileImageUrl = findMember.getProfileImageUrl();
+        return new MyProfileResponse(email, nickname, profileImageUrl);
     }
 }

--- a/src/main/java/haru/harudongseon/member/application/MemberService.java
+++ b/src/main/java/haru/harudongseon/member/application/MemberService.java
@@ -1,5 +1,6 @@
 package haru.harudongseon.member.application;
 
+import haru.harudongseon.member.application.dto.MyProfileEditRequest;
 import haru.harudongseon.member.application.dto.MyProfileResponse;
 import haru.harudongseon.member.domain.Member;
 import haru.harudongseon.member.domain.MemberRepository;
@@ -16,13 +17,21 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
-    public MyProfileResponse findMyProfile(Long memberId) {
+    public MyProfileResponse findMyProfile(final Long memberId) {
         final Member findMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException("해당하는 멤버를 찾을 수 없습니다."));
 
         final String email = findMember.getEmail();
         final String nickname = findMember.getNickname();
         final String profileImageUrl = findMember.getProfileImageUrl();
+
         return new MyProfileResponse(email, nickname, profileImageUrl);
+    }
+
+    public void editMyProfile(final Long memberId, final MyProfileEditRequest request) {
+        final Member findMember = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("해당하는 멤버를 찾을 수 없습니다."));
+
+        findMember.editProfile(request.nickname(), request.profileImageUrl());
     }
 }

--- a/src/main/java/haru/harudongseon/member/application/MemberService.java
+++ b/src/main/java/haru/harudongseon/member/application/MemberService.java
@@ -1,6 +1,6 @@
 package haru.harudongseon.member.application;
 
-import haru.harudongseon.member.application.dto.MyInfoResponse;
+import haru.harudongseon.member.application.dto.MyProfileResponse;
 import haru.harudongseon.member.domain.Member;
 import haru.harudongseon.member.domain.MemberRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -16,13 +16,13 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
-    public MyInfoResponse findMyInfo(Long memberId) {
+    public MyProfileResponse findMyProfile(Long memberId) {
         final Member findMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException("해당하는 멤버를 찾을 수 없습니다."));
 
         final String email = findMember.getEmail();
         final String nickname = findMember.getNickname();
         final String profileUrl = findMember.getProfileUrl();
-        return new MyInfoResponse(email, nickname, profileUrl);
+        return new MyProfileResponse(email, nickname, profileUrl);
     }
 }

--- a/src/main/java/haru/harudongseon/member/application/dto/LoginRequest.java
+++ b/src/main/java/haru/harudongseon/member/application/dto/LoginRequest.java
@@ -1,4 +1,0 @@
-package haru.harudongseon.member.application.dto;
-
-public record LoginRequest(String deviceId) {
-}

--- a/src/main/java/haru/harudongseon/member/application/dto/MyInfoResponse.java
+++ b/src/main/java/haru/harudongseon/member/application/dto/MyInfoResponse.java
@@ -1,0 +1,4 @@
+package haru.harudongseon.member.application.dto;
+
+public record MyInfoResponse(String email, String nickname, String profileUrl) {
+}

--- a/src/main/java/haru/harudongseon/member/application/dto/MyInfoResponse.java
+++ b/src/main/java/haru/harudongseon/member/application/dto/MyInfoResponse.java
@@ -1,4 +1,0 @@
-package haru.harudongseon.member.application.dto;
-
-public record MyInfoResponse(String email, String nickname, String profileUrl) {
-}

--- a/src/main/java/haru/harudongseon/member/application/dto/MyProfileEditRequest.java
+++ b/src/main/java/haru/harudongseon/member/application/dto/MyProfileEditRequest.java
@@ -1,0 +1,4 @@
+package haru.harudongseon.member.application.dto;
+
+public record MyProfileEditRequest() {
+}

--- a/src/main/java/haru/harudongseon/member/application/dto/MyProfileEditRequest.java
+++ b/src/main/java/haru/harudongseon/member/application/dto/MyProfileEditRequest.java
@@ -1,12 +1,16 @@
 package haru.harudongseon.member.application.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import org.hibernate.validator.constraints.URL;
 
 public record MyProfileEditRequest(
         @NotBlank(message = "수정할 닉네임은 공백일 수 없습니다. 변경하지 않으려면 기존 닉네임을 입력하세요.")
+        @Pattern(regexp = "^[a-zA-Z가-힣0-9\\\\s]{3,10}$", message = "수정할 닉네임은 한글, 영문, 숫자, 띄어쓰기 포함 3~10자 여야합니다.")
         String nickname,
 
         @NotBlank(message = "수정할 프로필 이미지 URL은 공백일 수 없습니다. 변경하지 않으려면 기존 프로필 이미지 URL을 입력하세요.")
+        @URL(message = "수정할 프로필 이미지 URL은 URL 형식이어야합니다.")
         String profileImageUrl
 ) {
 }

--- a/src/main/java/haru/harudongseon/member/application/dto/MyProfileEditRequest.java
+++ b/src/main/java/haru/harudongseon/member/application/dto/MyProfileEditRequest.java
@@ -1,14 +1,17 @@
 package haru.harudongseon.member.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import org.hibernate.validator.constraints.URL;
 
 public record MyProfileEditRequest(
+        @Schema(description = "수정할 닉네임(한글, 영문, 숫자, 띄어쓰기 포함 3~10자)", nullable = false, example = "SUPER SEONGHA")
         @NotBlank(message = "수정할 닉네임은 공백일 수 없습니다. 변경하지 않으려면 기존 닉네임을 입력하세요.")
         @Pattern(regexp = "^[a-zA-Z가-힣0-9\\\\s]{3,10}$", message = "수정할 닉네임은 한글, 영문, 숫자, 띄어쓰기 포함 3~10자 여야합니다.")
         String nickname,
 
+        @Schema(description = "수정할 프로필 이미지 URL", nullable = false, example = "https://lh3.googleusercontent.com/a/xxx")
         @NotBlank(message = "수정할 프로필 이미지 URL은 공백일 수 없습니다. 변경하지 않으려면 기존 프로필 이미지 URL을 입력하세요.")
         @URL(message = "수정할 프로필 이미지 URL은 URL 형식이어야합니다.")
         String profileImageUrl

--- a/src/main/java/haru/harudongseon/member/application/dto/MyProfileEditRequest.java
+++ b/src/main/java/haru/harudongseon/member/application/dto/MyProfileEditRequest.java
@@ -1,4 +1,12 @@
 package haru.harudongseon.member.application.dto;
 
-public record MyProfileEditRequest() {
+import jakarta.validation.constraints.NotBlank;
+
+public record MyProfileEditRequest(
+        @NotBlank(message = "수정할 닉네임은 공백일 수 없습니다. 변경하지 않으려면 기존 닉네임을 입력하세요.")
+        String nickname,
+
+        @NotBlank(message = "수정할 프로필 이미지 URL은 공백일 수 없습니다. 변경하지 않으려면 기존 프로필 이미지 URL을 입력하세요.")
+        String profileImageUrl
+) {
 }

--- a/src/main/java/haru/harudongseon/member/application/dto/MyProfileResponse.java
+++ b/src/main/java/haru/harudongseon/member/application/dto/MyProfileResponse.java
@@ -1,4 +1,13 @@
 package haru.harudongseon.member.application.dto;
 
-public record MyProfileResponse(String email, String nickname, String profileImageUrl) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MyProfileResponse(
+        @Schema(description = "회원 이메일", example = "seongha@gmail.com")
+        String email,
+        @Schema(description = "회원 닉네임", example = "seongha")
+        String nickname,
+        @Schema(description = "회원 프로필 이미지 URL", example = "https://lh3.googleusercontent.com/a/xxx")
+        String profileImageUrl
+) {
 }

--- a/src/main/java/haru/harudongseon/member/application/dto/MyProfileResponse.java
+++ b/src/main/java/haru/harudongseon/member/application/dto/MyProfileResponse.java
@@ -1,4 +1,4 @@
 package haru.harudongseon.member.application.dto;
 
-public record MyProfileResponse(String email, String nickname, String profileUrl) {
+public record MyProfileResponse(String email, String nickname, String profileImageUrl) {
 }

--- a/src/main/java/haru/harudongseon/member/application/dto/MyProfileResponse.java
+++ b/src/main/java/haru/harudongseon/member/application/dto/MyProfileResponse.java
@@ -1,0 +1,4 @@
+package haru.harudongseon.member.application.dto;
+
+public record MyProfileResponse(String email, String nickname, String profileUrl) {
+}

--- a/src/main/java/haru/harudongseon/member/application/dto/OauthLoginRequest.java
+++ b/src/main/java/haru/harudongseon/member/application/dto/OauthLoginRequest.java
@@ -1,13 +1,17 @@
 package haru.harudongseon.member.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 public record OauthLoginRequest(
         @NotBlank(message = "로그인 타입은 공백일 수 없습니다.")
+        @Schema(description = "OAuth 타입", nullable = false, example = "google / naver / kakao")
         String loginType,
         @NotBlank(message = "OAuth 인증 토큰은 공백일 수 없습니다.")
+        @Schema(description = "OAuth 인증 코드/토큰", nullable = false, example = "xxx.xxx.xxx")
         String token,
         @NotBlank(message = "Device ID는 공백일 수 없습니다.")
+        @Schema(description = "기기 디바이스 ID", nullable = false, example = "aaaa12")
         String deviceId
 ) {
 }

--- a/src/main/java/haru/harudongseon/member/application/dto/OauthLoginResponse.java
+++ b/src/main/java/haru/harudongseon/member/application/dto/OauthLoginResponse.java
@@ -1,4 +1,11 @@
 package haru.harudongseon.member.application.dto;
 
-public record OauthLoginResponse(String accessToken, Boolean isNewMember) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record OauthLoginResponse(
+        @Schema(description = "자체 Access Token", nullable = false, example = "xxx.xxx.xxx")
+        String accessToken,
+        @Schema(description = "회원가입(첫 로그인) / 로그인 판단 플래그", nullable = false, example = "true")
+        Boolean isNewMember
+) {
 }

--- a/src/main/java/haru/harudongseon/member/domain/Member.java
+++ b/src/main/java/haru/harudongseon/member/domain/Member.java
@@ -38,4 +38,9 @@ public class Member extends BaseEntity {
         this.deviceId = deviceId;
         this.loginType = loginType;
     }
+
+    public void editProfile(final String nickname, final String profileImageUrl) {
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
 }

--- a/src/main/java/haru/harudongseon/member/domain/Member.java
+++ b/src/main/java/haru/harudongseon/member/domain/Member.java
@@ -19,7 +19,7 @@ public class Member extends BaseEntity {
 
     private String nickname;
 
-    private String profileUrl;
+    private String profileImageUrl;
 
     private String oauthId;
 
@@ -29,11 +29,11 @@ public class Member extends BaseEntity {
     private LoginType loginType;
 
     public Member(final String email, final String nickname,
-                  final String profileUrl, final String oauthId,
+                  final String profileImageUrl, final String oauthId,
                   final String deviceId, final LoginType loginType) {
         this.email = email;
         this.nickname = nickname;
-        this.profileUrl = profileUrl;
+        this.profileImageUrl = profileImageUrl;
         this.oauthId = oauthId;
         this.deviceId = deviceId;
         this.loginType = loginType;

--- a/src/main/java/haru/harudongseon/member/presentation/LoginController.java
+++ b/src/main/java/haru/harudongseon/member/presentation/LoginController.java
@@ -1,8 +1,13 @@
 package haru.harudongseon.member.presentation;
 
+import haru.harudongseon.global.exception.ErrorResponse;
 import haru.harudongseon.member.application.LoginService;
 import haru.harudongseon.member.application.dto.OauthLoginResponse;
 import haru.harudongseon.member.application.dto.OauthLoginRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +21,9 @@ public class LoginController {
 
     private final LoginService loginService;
 
+    @Operation(summary = "OAuth 로그인 API")
+    @ApiResponse(responseCode = "200", description = "로그인 성공")
+    @ApiResponse(responseCode = "500", description = "로그인 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
     @PostMapping("/oauth-login")
     public ResponseEntity<OauthLoginResponse> memberLogin(@Valid @RequestBody final OauthLoginRequest oauthLoginRequest) {
         final OauthLoginResponse loginResponse = loginService.oauthLogin(oauthLoginRequest);

--- a/src/main/java/haru/harudongseon/member/presentation/MemberController.java
+++ b/src/main/java/haru/harudongseon/member/presentation/MemberController.java
@@ -3,12 +3,12 @@ package haru.harudongseon.member.presentation;
 import haru.harudongseon.global.mvc.AuthMemberDto;
 import haru.harudongseon.global.mvc.AuthPrincipal;
 import haru.harudongseon.member.application.MemberService;
+import haru.harudongseon.member.application.dto.MyProfileEditRequest;
 import haru.harudongseon.member.application.dto.MyProfileResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/members")
@@ -21,5 +21,12 @@ public class MemberController {
     public ResponseEntity<MyProfileResponse> getMyProfile(@AuthPrincipal AuthMemberDto authMemberDto) {
         final MyProfileResponse response = memberService.findMyProfile(authMemberDto.memberId());
         return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/me")
+    public ResponseEntity<MyProfileResponse> editMyProfile(@AuthPrincipal AuthMemberDto authMemberDto,
+                                                          @Valid @RequestBody MyProfileEditRequest request) {
+        memberService.editMyProfile(authMemberDto.memberId(), request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/haru/harudongseon/member/presentation/MemberController.java
+++ b/src/main/java/haru/harudongseon/member/presentation/MemberController.java
@@ -3,7 +3,7 @@ package haru.harudongseon.member.presentation;
 import haru.harudongseon.global.mvc.AuthMemberDto;
 import haru.harudongseon.global.mvc.AuthPrincipal;
 import haru.harudongseon.member.application.MemberService;
-import haru.harudongseon.member.application.dto.MyInfoResponse;
+import haru.harudongseon.member.application.dto.MyProfileResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,8 +18,8 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/me")
-    public ResponseEntity<MyInfoResponse> getMyInfo(@AuthPrincipal AuthMemberDto authMemberDto) {
-        final MyInfoResponse response = memberService.findMyInfo(authMemberDto.memberId());
+    public ResponseEntity<MyProfileResponse> getMyProfile(@AuthPrincipal AuthMemberDto authMemberDto) {
+        final MyProfileResponse response = memberService.findMyProfile(authMemberDto.memberId());
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/haru/harudongseon/member/presentation/MemberController.java
+++ b/src/main/java/haru/harudongseon/member/presentation/MemberController.java
@@ -1,15 +1,25 @@
 package haru.harudongseon.member.presentation;
 
+import haru.harudongseon.global.exception.ErrorResponse;
 import haru.harudongseon.global.mvc.AuthMemberDto;
 import haru.harudongseon.global.mvc.AuthPrincipal;
 import haru.harudongseon.member.application.MemberService;
 import haru.harudongseon.member.application.dto.MyProfileEditRequest;
 import haru.harudongseon.member.application.dto.MyProfileResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "MEMBER API", description = "회원 관련 API")
 @RestController
 @RequestMapping("/members")
 @RequiredArgsConstructor
@@ -17,14 +27,22 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    @Operation(summary = "내 정보 조회 API")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiResponse(responseCode = "400", description = "요청 Field Error", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+    @ApiResponse(responseCode = "404", description = "멤버 Not Found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
     @GetMapping("/me")
-    public ResponseEntity<MyProfileResponse> getMyProfile(@AuthPrincipal AuthMemberDto authMemberDto) {
+    public ResponseEntity<MyProfileResponse> getMyProfile(
+            @Parameter(hidden = true) @AuthPrincipal AuthMemberDto authMemberDto) {
         final MyProfileResponse response = memberService.findMyProfile(authMemberDto.memberId());
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "내 정보 수정 API")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiResponse(responseCode = "404", description = "멤버 Not Found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
     @PatchMapping("/me")
-    public ResponseEntity<MyProfileResponse> editMyProfile(@AuthPrincipal AuthMemberDto authMemberDto,
+    public ResponseEntity<MyProfileResponse> editMyProfile(@Parameter(hidden = true) @AuthPrincipal AuthMemberDto authMemberDto,
                                                           @Valid @RequestBody MyProfileEditRequest request) {
         memberService.editMyProfile(authMemberDto.memberId(), request);
         return ResponseEntity.ok().build();

--- a/src/main/java/haru/harudongseon/member/presentation/MemberController.java
+++ b/src/main/java/haru/harudongseon/member/presentation/MemberController.java
@@ -1,0 +1,25 @@
+package haru.harudongseon.member.presentation;
+
+import haru.harudongseon.global.mvc.AuthMemberDto;
+import haru.harudongseon.global.mvc.AuthPrincipal;
+import haru.harudongseon.member.application.MemberService;
+import haru.harudongseon.member.application.dto.MyInfoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/me")
+    public ResponseEntity<MyInfoResponse> getMyInfo(@AuthPrincipal AuthMemberDto authMemberDto) {
+        final MyInfoResponse response = memberService.findMyInfo(authMemberDto.memberId());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/test/java/haru/harudongseon/common/H2TruncateUtils.java
+++ b/src/test/java/haru/harudongseon/common/H2TruncateUtils.java
@@ -1,0 +1,35 @@
+package haru.harudongseon.common;
+
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class H2TruncateUtils {
+
+    @Autowired
+    private EntityManager em;
+
+    @Transactional
+    public void truncateAll() {
+        em.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        final List<String> tableNames = em.getMetamodel().getEntities().stream()
+                .map(entityType -> {
+                    final String name = entityType.getName();
+                    return camelToSnake(name);
+                })
+                .toList();
+
+        for (String tableName : tableNames) {
+            em.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+        }
+        em.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+
+    private String camelToSnake(String str) {
+        return str.replaceAll("([a-z0-9])([A-Z])", "$1_$2").toLowerCase();
+    }
+}

--- a/src/test/java/haru/harudongseon/common/builder/MemberBuilder.java
+++ b/src/test/java/haru/harudongseon/common/builder/MemberBuilder.java
@@ -1,0 +1,70 @@
+package haru.harudongseon.common.builder;
+
+import static haru.harudongseon.common.fixtures.member.MemberFixtures.*;
+
+import haru.harudongseon.global.oauth.LoginType;
+import haru.harudongseon.member.domain.Member;
+import haru.harudongseon.member.domain.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberBuilder {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private String email;
+    private String nickname;
+    private String profileUrl;
+    private String oauthId;
+    private String deviceId;
+    private LoginType loginType;
+
+    public MemberBuilder defaultMember() {
+        this.email = 성하_이메일;
+        this.nickname = 성하_닉네임;
+        this.profileUrl = 성하_프로필_URL;
+        this.oauthId = 성하_OAUTH_ID;
+        this.deviceId = 성하_DEVICE_ID;
+        this.loginType = 성하_LOGIN_TYPE;
+
+        return this;
+    }
+
+    public MemberBuilder email(final String email) {
+        this.email = email;
+        return this;
+    }
+
+    public MemberBuilder nickname(final String nickname) {
+        this.nickname = nickname;
+        return this;
+    }
+
+    public MemberBuilder profileUrl(final String profileUrl) {
+        this.profileUrl = profileUrl;
+        return this;
+    }
+
+    public MemberBuilder oauthId(final String oauthId) {
+        this.oauthId = oauthId;
+        return this;
+    }
+
+    public MemberBuilder deviceId(final String deviceId) {
+        this.deviceId = deviceId;
+        return this;
+    }
+
+    public MemberBuilder loginType(final LoginType loginType) {
+        this.loginType = loginType;
+        return this;
+    }
+
+    public Member build() {
+        final Member member = new Member(email, nickname, profileUrl, oauthId, deviceId, loginType);
+        return memberRepository.save(member);
+    }
+
+}

--- a/src/test/java/haru/harudongseon/common/builder/MemberBuilder.java
+++ b/src/test/java/haru/harudongseon/common/builder/MemberBuilder.java
@@ -16,7 +16,7 @@ public class MemberBuilder {
 
     private String email;
     private String nickname;
-    private String profileUrl;
+    private String profileImageUrl;
     private String oauthId;
     private String deviceId;
     private LoginType loginType;
@@ -24,7 +24,7 @@ public class MemberBuilder {
     public MemberBuilder defaultMember() {
         this.email = 성하_이메일;
         this.nickname = 성하_닉네임;
-        this.profileUrl = 성하_프로필_URL;
+        this.profileImageUrl = 성하_프로필_이미지_URL;
         this.oauthId = 성하_OAUTH_ID;
         this.deviceId = 성하_DEVICE_ID;
         this.loginType = 성하_LOGIN_TYPE;
@@ -42,8 +42,8 @@ public class MemberBuilder {
         return this;
     }
 
-    public MemberBuilder profileUrl(final String profileUrl) {
-        this.profileUrl = profileUrl;
+    public MemberBuilder profileImageUrl(final String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
         return this;
     }
 
@@ -63,7 +63,7 @@ public class MemberBuilder {
     }
 
     public Member build() {
-        final Member member = new Member(email, nickname, profileUrl, oauthId, deviceId, loginType);
+        final Member member = new Member(email, nickname, profileImageUrl, oauthId, deviceId, loginType);
         return memberRepository.save(member);
     }
 

--- a/src/test/java/haru/harudongseon/common/fixtures/member/MemberFixtures.java
+++ b/src/test/java/haru/harudongseon/common/fixtures/member/MemberFixtures.java
@@ -9,7 +9,7 @@ public class MemberFixtures {
      */
     public static final String 성하_이메일 = "seongha@gmail.com";
     public static final String 성하_닉네임 = "SEONGHA";
-    public static final String 성하_프로필_URL = "SEONGHA";
+    public static final String 성하_프로필_이미지_URL = "SEONGHA";
     public static final String 성하_OAUTH_ID = "a12345";
     public static final String 성하_DEVICE_ID = "abc1234";
     public static final LoginType 성하_LOGIN_TYPE = LoginType.NAVER;

--- a/src/test/java/haru/harudongseon/common/fixtures/member/MemberFixtures.java
+++ b/src/test/java/haru/harudongseon/common/fixtures/member/MemberFixtures.java
@@ -9,7 +9,7 @@ public class MemberFixtures {
      */
     public static final String 성하_이메일 = "seongha@gmail.com";
     public static final String 성하_닉네임 = "SEONGHA";
-    public static final String 성하_프로필_이미지_URL = "SEONGHA";
+    public static final String 성하_프로필_이미지_URL = "https://lh3.googleusercontent.com/a/xxx";
     public static final String 성하_OAUTH_ID = "a12345";
     public static final String 성하_DEVICE_ID = "abc1234";
     public static final LoginType 성하_LOGIN_TYPE = LoginType.NAVER;

--- a/src/test/java/haru/harudongseon/common/fixtures/member/MemberFixtures.java
+++ b/src/test/java/haru/harudongseon/common/fixtures/member/MemberFixtures.java
@@ -1,0 +1,17 @@
+package haru.harudongseon.common.fixtures.member;
+
+import haru.harudongseon.global.oauth.LoginType;
+
+public class MemberFixtures {
+
+    /**
+     * 멤버 1 (성하)
+     */
+    public static final String 성하_이메일 = "seongha@gmail.com";
+    public static final String 성하_닉네임 = "SEONGHA";
+    public static final String 성하_프로필_URL = "SEONGHA";
+    public static final String 성하_OAUTH_ID = "a12345";
+    public static final String 성하_DEVICE_ID = "abc1234";
+    public static final LoginType 성하_LOGIN_TYPE = LoginType.NAVER;
+
+}

--- a/src/test/java/haru/harudongseon/member/application/MemberServiceTest.java
+++ b/src/test/java/haru/harudongseon/member/application/MemberServiceTest.java
@@ -1,0 +1,62 @@
+package haru.harudongseon.member.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import haru.harudongseon.common.builder.MemberBuilder;
+import haru.harudongseon.member.application.dto.MyInfoResponse;
+import haru.harudongseon.member.domain.Member;
+import haru.harudongseon.member.domain.MemberRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class MemberServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberBuilder memberBuilder;
+
+
+    @Nested
+    @DisplayName("내 정보 조회 시")
+    class FindMyInfo {
+
+        @Test
+        @DisplayName("내 정보 조회에 성공한다.")
+        void success() {
+            // given
+            final Member member = memberBuilder.defaultMember().build();
+            final Long memberId = member.getId();
+            final MyInfoResponse expected = new MyInfoResponse(member.getEmail(), member.getNickname(), member.getProfileUrl());
+
+            // when
+            final MyInfoResponse actual = memberService.findMyInfo(memberId);
+
+            // then
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("멤버 ID에 해당하는 멤버가 없으면 예외가 발생한다.")
+        void throws_not_found_member() {
+            // given
+            final Long notExistMemberId = -1L;
+
+            // when & then
+            assertThatThrownBy(() -> memberService.findMyInfo(notExistMemberId))
+                    .isInstanceOf(EntityNotFoundException.class)
+                    .hasMessage("해당하는 멤버를 찾을 수 없습니다.");
+        }
+    }
+}

--- a/src/test/java/haru/harudongseon/member/application/MemberServiceTest.java
+++ b/src/test/java/haru/harudongseon/member/application/MemberServiceTest.java
@@ -2,14 +2,11 @@ package haru.harudongseon.member.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 
 import haru.harudongseon.common.builder.MemberBuilder;
-import haru.harudongseon.member.application.dto.MyInfoResponse;
+import haru.harudongseon.member.application.dto.MyProfileResponse;
 import haru.harudongseon.member.domain.Member;
-import haru.harudongseon.member.domain.MemberRepository;
 import jakarta.persistence.EntityNotFoundException;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,7 +27,7 @@ class MemberServiceTest {
 
     @Nested
     @DisplayName("내 정보 조회 시")
-    class FindMyInfo {
+    class FindMyProfile {
 
         @Test
         @DisplayName("내 정보 조회에 성공한다.")
@@ -38,10 +35,10 @@ class MemberServiceTest {
             // given
             final Member member = memberBuilder.defaultMember().build();
             final Long memberId = member.getId();
-            final MyInfoResponse expected = new MyInfoResponse(member.getEmail(), member.getNickname(), member.getProfileUrl());
+            final MyProfileResponse expected = new MyProfileResponse(member.getEmail(), member.getNickname(), member.getProfileUrl());
 
             // when
-            final MyInfoResponse actual = memberService.findMyInfo(memberId);
+            final MyProfileResponse actual = memberService.findMyProfile(memberId);
 
             // then
             assertThat(actual).isEqualTo(expected);
@@ -54,7 +51,7 @@ class MemberServiceTest {
             final Long notExistMemberId = -1L;
 
             // when & then
-            assertThatThrownBy(() -> memberService.findMyInfo(notExistMemberId))
+            assertThatThrownBy(() -> memberService.findMyProfile(notExistMemberId))
                     .isInstanceOf(EntityNotFoundException.class)
                     .hasMessage("해당하는 멤버를 찾을 수 없습니다.");
         }

--- a/src/test/java/haru/harudongseon/member/application/MemberServiceTest.java
+++ b/src/test/java/haru/harudongseon/member/application/MemberServiceTest.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import haru.harudongseon.common.builder.MemberBuilder;
+import haru.harudongseon.member.application.dto.MyProfileEditRequest;
 import haru.harudongseon.member.application.dto.MyProfileResponse;
 import haru.harudongseon.member.domain.Member;
+import haru.harudongseon.member.domain.MemberRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -16,7 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
-class MemberServiceTest {
+public class MemberServiceTest {
 
     @Autowired
     private MemberService memberService;
@@ -24,6 +26,8 @@ class MemberServiceTest {
     @Autowired
     private MemberBuilder memberBuilder;
 
+    @Autowired
+    private MemberRepository memberRepository;
 
     @Nested
     @DisplayName("내 정보 조회 시")
@@ -52,6 +56,103 @@ class MemberServiceTest {
 
             // when & then
             assertThatThrownBy(() -> memberService.findMyProfile(notExistMemberId))
+                    .isInstanceOf(EntityNotFoundException.class)
+                    .hasMessage("해당하는 멤버를 찾을 수 없습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("내 정보 수정 시")
+    class EditMyProfile {
+
+        @Test
+        @DisplayName("수정할 정보가 같은 정보라도 내 정보 수정에 성공한다.")
+        void success_same_info_profile() {
+            // given
+            final Member member = memberBuilder.defaultMember().build();
+            final Long memberId = member.getId();
+            final String nickname = member.getNickname();
+            final String profileImageUrl = member.getProfileImageUrl();
+            final MyProfileEditRequest request = new MyProfileEditRequest(nickname, profileImageUrl);
+
+            // when
+            memberService.editMyProfile(memberId, request);
+            final Member findMember = memberRepository.findById(memberId).get();
+
+            // then
+            assertThat(findMember.getNickname()).isEqualTo(nickname);
+            assertThat(findMember.getProfileImageUrl()).isEqualTo(profileImageUrl);
+        }
+
+        @Test
+        @DisplayName("닉네임만 수정 시 내 정보 수정에 성공한다.")
+        void success_edit_nickname() {
+            // given
+            final Member member = memberBuilder.defaultMember().build();
+            final Long memberId = member.getId();
+            System.out.println("memberId = " + memberId);
+            final String nicknameToEdit = "edited " + member.getNickname();
+            final String profileImageUrl = member.getProfileImageUrl();
+            final MyProfileEditRequest request = new MyProfileEditRequest(nicknameToEdit, profileImageUrl);
+
+            // when
+            memberService.editMyProfile(memberId, request);
+            final Member findMember = memberRepository.findById(memberId).get();
+
+            // then
+            assertThat(findMember.getNickname()).isEqualTo(nicknameToEdit);
+            assertThat(findMember.getProfileImageUrl()).isEqualTo(profileImageUrl);
+        }
+
+        @Test
+        @DisplayName("프로필 이미지 URL만 수정 시 내 정보 수정에 성공한다.")
+        void success_edit_profile_image_url() {
+            // given
+            final Member member = memberBuilder.defaultMember().build();
+            final Long memberId = member.getId();
+            final String nickname = member.getNickname();
+            final String profileImageUrlToEdit = "edited " + member.getProfileImageUrl();
+            final MyProfileEditRequest request = new MyProfileEditRequest(nickname, profileImageUrlToEdit);
+
+            // when
+            memberService.editMyProfile(memberId, request);
+            final Member findMember = memberRepository.findById(memberId).get();
+
+            // then
+            assertThat(findMember.getNickname()).isEqualTo(nickname);
+            assertThat(findMember.getProfileImageUrl()).isEqualTo(profileImageUrlToEdit);
+        }
+
+        @Test
+        @DisplayName("모든 정보 수정 시 내 정보 수정에 성공한다.")
+        void success_edit_profile_all() {
+            // given
+            final Member member = memberBuilder.defaultMember().build();
+            final Long memberId = member.getId();
+            final String nicknameToEdit = "edited " + member.getNickname();
+            final String profileImageUrlToEdit = "edited " + member.getProfileImageUrl();
+            final MyProfileEditRequest request = new MyProfileEditRequest(nicknameToEdit, profileImageUrlToEdit);
+
+            // when
+            memberService.editMyProfile(memberId, request);
+            final Member findMember = memberRepository.findById(memberId).get();
+
+            // then
+            assertThat(findMember.getNickname()).isEqualTo(nicknameToEdit);
+            assertThat(findMember.getProfileImageUrl()).isEqualTo(profileImageUrlToEdit);
+        }
+
+        @Test
+        @DisplayName("멤버 ID에 해당하는 멤버가 없으면 예외가 발생한다.")
+        void throws_not_found_member() {
+            // given
+            final Long notExistMemberId = -1L;
+            final String nicknameToEdit = "edited Nickname";
+            final String profileImageUrlToEdit = "edited ProfileImageUrl";
+            final MyProfileEditRequest request = new MyProfileEditRequest(nicknameToEdit, profileImageUrlToEdit);
+
+            // when & then
+            assertThatThrownBy(() -> memberService.editMyProfile(notExistMemberId, request))
                     .isInstanceOf(EntityNotFoundException.class)
                     .hasMessage("해당하는 멤버를 찾을 수 없습니다.");
         }

--- a/src/test/java/haru/harudongseon/member/application/MemberServiceTest.java
+++ b/src/test/java/haru/harudongseon/member/application/MemberServiceTest.java
@@ -35,7 +35,7 @@ class MemberServiceTest {
             // given
             final Member member = memberBuilder.defaultMember().build();
             final Long memberId = member.getId();
-            final MyProfileResponse expected = new MyProfileResponse(member.getEmail(), member.getNickname(), member.getProfileUrl());
+            final MyProfileResponse expected = new MyProfileResponse(member.getEmail(), member.getNickname(), member.getProfileImageUrl());
 
             // when
             final MyProfileResponse actual = memberService.findMyProfile(memberId);

--- a/src/test/java/haru/harudongseon/member/presentation/MemberControllerTest.java
+++ b/src/test/java/haru/harudongseon/member/presentation/MemberControllerTest.java
@@ -1,18 +1,15 @@
 package haru.harudongseon.member.presentation;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.junit.jupiter.api.Assertions.*;
 
 import haru.harudongseon.common.H2TruncateUtils;
 import haru.harudongseon.common.builder.MemberBuilder;
 import haru.harudongseon.global.jwt.JwtService;
 import haru.harudongseon.member.domain.Member;
 import io.restassured.RestAssured;
-import io.restassured.http.Header;
 import io.restassured.path.json.JsonPath;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -48,7 +45,7 @@ class MemberControllerTest {
 
     @Nested
     @DisplayName("내 정보 조회 시")
-    class GetMyInfo {
+    class GetMyProfile {
 
         @Test
         @DisplayName("내 정보 조회에 성공한다.")
@@ -62,7 +59,7 @@ class MemberControllerTest {
             final String accessToken = jwtService.createAccessToken(memberId);
 
             // when
-            final ExtractableResponse<Response> response = GET_MY_INFO_REQUEST(accessToken);
+            final ExtractableResponse<Response> response = GET_MY_PROFILE_REQUEST(accessToken);
             final JsonPath jsonPath = response.jsonPath();
 
             // then
@@ -82,7 +79,7 @@ class MemberControllerTest {
             final String accessToken = jwtService.createAccessToken(notExistMemberId);
 
             // when
-            final ExtractableResponse<Response> response = GET_MY_INFO_REQUEST(accessToken);
+            final ExtractableResponse<Response> response = GET_MY_PROFILE_REQUEST(accessToken);
 
             // then
             assertSoftly(softly -> {
@@ -92,7 +89,7 @@ class MemberControllerTest {
         }
     }
 
-    private static ExtractableResponse<Response> GET_MY_INFO_REQUEST(final String accessToken) {
+    private static ExtractableResponse<Response> GET_MY_PROFILE_REQUEST(final String accessToken) {
         return RestAssured.given().log().all()
                 .header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + accessToken)
                 .when().log().all()

--- a/src/test/java/haru/harudongseon/member/presentation/MemberControllerTest.java
+++ b/src/test/java/haru/harudongseon/member/presentation/MemberControllerTest.java
@@ -1,0 +1,103 @@
+package haru.harudongseon.member.presentation;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.junit.jupiter.api.Assertions.*;
+
+import haru.harudongseon.common.H2TruncateUtils;
+import haru.harudongseon.common.builder.MemberBuilder;
+import haru.harudongseon.global.jwt.JwtService;
+import haru.harudongseon.member.domain.Member;
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class MemberControllerTest {
+    
+    private static final String JWT_PREFIX = "Bearer ";
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private H2TruncateUtils h2TruncateUtils;
+
+    @Autowired
+    private MemberBuilder memberBuilder;
+    
+    @Autowired
+    private JwtService jwtService;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = this.port;
+        h2TruncateUtils.truncateAll();
+    }
+
+    @Nested
+    @DisplayName("내 정보 조회 시")
+    class GetMyInfo {
+
+        @Test
+        @DisplayName("내 정보 조회에 성공한다.")
+        void success() {
+            // given
+            final Member savedMember = memberBuilder.defaultMember().build();
+            final Long memberId = savedMember.getId();
+            final String email = savedMember.getEmail();
+            final String nickname = savedMember.getNickname();
+            final String profileUrl = savedMember.getProfileUrl();
+            final String accessToken = jwtService.createAccessToken(memberId);
+
+            // when
+            final ExtractableResponse<Response> response = GET_MY_INFO_REQUEST(accessToken);
+            final JsonPath jsonPath = response.jsonPath();
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+                softly.assertThat(jsonPath.getString("email")).isEqualTo(email);
+                softly.assertThat(jsonPath.getString("nickname")).isEqualTo(nickname);
+                softly.assertThat(jsonPath.getString("profileUrl")).isEqualTo(profileUrl);
+            });
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 멤버의 내 정보 조회면 실패한다.")
+        void fail_get_not_exist_member_info() {
+            // given
+            final Long notExistMemberId = -1L;
+            final String accessToken = jwtService.createAccessToken(notExistMemberId);
+
+            // when
+            final ExtractableResponse<Response> response = GET_MY_INFO_REQUEST(accessToken);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+                softly.assertThat(response.jsonPath().getString("errorMessage")).isEqualTo("해당하는 멤버를 찾을 수 없습니다.");
+            });
+        }
+    }
+
+    private static ExtractableResponse<Response> GET_MY_INFO_REQUEST(final String accessToken) {
+        return RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + accessToken)
+                .when().log().all()
+                .get("/members/me")
+                .then().log().all()
+                .extract();
+    }
+}

--- a/src/test/java/haru/harudongseon/member/presentation/MemberControllerTest.java
+++ b/src/test/java/haru/harudongseon/member/presentation/MemberControllerTest.java
@@ -55,7 +55,7 @@ class MemberControllerTest {
             final Long memberId = savedMember.getId();
             final String email = savedMember.getEmail();
             final String nickname = savedMember.getNickname();
-            final String profileUrl = savedMember.getProfileUrl();
+            final String profileImageUrl = savedMember.getProfileImageUrl();
             final String accessToken = jwtService.createAccessToken(memberId);
 
             // when
@@ -67,7 +67,7 @@ class MemberControllerTest {
                 softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
                 softly.assertThat(jsonPath.getString("email")).isEqualTo(email);
                 softly.assertThat(jsonPath.getString("nickname")).isEqualTo(nickname);
-                softly.assertThat(jsonPath.getString("profileUrl")).isEqualTo(profileUrl);
+                softly.assertThat(jsonPath.getString("profileImageUrl")).isEqualTo(profileImageUrl);
             });
         }
 

--- a/src/test/java/haru/harudongseon/member/presentation/MemberControllerTest.java
+++ b/src/test/java/haru/harudongseon/member/presentation/MemberControllerTest.java
@@ -1,24 +1,35 @@
 package haru.harudongseon.member.presentation;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.util.stream.Stream;
 
 import haru.harudongseon.common.H2TruncateUtils;
 import haru.harudongseon.common.builder.MemberBuilder;
+import haru.harudongseon.common.fixtures.member.MemberFixtures;
 import haru.harudongseon.global.jwt.JwtService;
+import haru.harudongseon.member.application.dto.MyProfileEditRequest;
 import haru.harudongseon.member.domain.Member;
 import io.restassured.RestAssured;
 import io.restassured.path.json.JsonPath;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class MemberControllerTest {
@@ -89,11 +100,93 @@ class MemberControllerTest {
         }
     }
 
+    @Nested
+    @DisplayName("내 정보 수정 시")
+    class EditMyProfile {
+
+        @ParameterizedTest
+        @MethodSource("editRequests")
+        @DisplayName("수정에 성공한다.")
+        void success(final MyProfileEditRequest request) {
+            // given
+            final Member savedMember = memberBuilder.defaultMember().build();
+            final Long memberId = savedMember.getId();
+            final String accessToken = jwtService.createAccessToken(memberId);
+
+            // when
+            final ExtractableResponse<Response> response = EDIT_MY_PROFILE_REQUEST(accessToken, request);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        }
+
+        private static Stream<Arguments> editRequests() {
+            final String nickname = MemberFixtures.성하_닉네임;
+            final String profileImageUrl = MemberFixtures.성하_프로필_이미지_URL;
+
+            return Stream.of(
+                    Arguments.arguments(new MyProfileEditRequest(nickname, profileImageUrl)),
+                    Arguments.arguments(new MyProfileEditRequest("edited " + nickname, profileImageUrl)),
+                    Arguments.arguments(new MyProfileEditRequest(nickname, "edited " + profileImageUrl)),
+                    Arguments.arguments(new MyProfileEditRequest("edtied " + nickname, "edited " + profileImageUrl))
+            );
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 멤버의 내 정보 수정이면 실패한다.")
+        void fail_edit_not_exist_member_profile() {
+            // given
+            final Long notExistMemberId = -1L;
+            final String accessToken = jwtService.createAccessToken(notExistMemberId);
+            final MyProfileEditRequest request = new MyProfileEditRequest("edited nickname", "edited profileImageUrl");
+
+            // when
+            final ExtractableResponse<Response> response = EDIT_MY_PROFILE_REQUEST(accessToken, request);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+                softly.assertThat(response.jsonPath().getString("errorMessage")).isEqualTo("해당하는 멤버를 찾을 수 없습니다.");
+            });
+        }
+
+        @ParameterizedTest
+        @CsvSource(value = {":edited profileUrl", "edited nickname:", ":"}, delimiter = ':')
+        @DisplayName("정보가 하나라도 빈 값이면 내 정보 수정이 실패한다.")
+        void fail_edit_profile_request_blank(final String nickname, final String profileImageUrl) {
+            // given
+            final Member savedMember = memberBuilder.defaultMember().build();
+            final Long memberId = savedMember.getId();
+            final String accessToken = jwtService.createAccessToken(memberId);
+            final MyProfileEditRequest request = new MyProfileEditRequest(nickname, profileImageUrl);
+
+            // when
+            final ExtractableResponse<Response> response = EDIT_MY_PROFILE_REQUEST(accessToken, request);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+                softly.assertThat(response.jsonPath().getString("errorMessage")).contains("공백일 수 없습니다.");
+            });
+        }
+    }
+
     private static ExtractableResponse<Response> GET_MY_PROFILE_REQUEST(final String accessToken) {
         return RestAssured.given().log().all()
                 .header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + accessToken)
                 .when().log().all()
                 .get("/members/me")
+                .then().log().all()
+                .extract();
+    }
+
+    private static ExtractableResponse<Response> EDIT_MY_PROFILE_REQUEST(final String accessToken, final MyProfileEditRequest request) {
+        return RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when().log().all()
+                .patch("/members/me")
                 .then().log().all()
                 .extract();
     }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:haru-dongseon
+    
+  h2:
+    console:
+      enabled: true
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: true
+    show-sql: true


### PR DESCRIPTION
## 🔥 연관 이슈

- close #6 
- close #7 
- close #12 

## 🚀 작업 내용

### 내 정보 조회 API

* AccessToken 추출해서 MemberId를 가져오는 `MemeberArgumentResolver` 구현
* API 정보는 Swagger 및 이슈 참고
* 테스트 구현


### 내 정보 수정 API

* Request Body로 닉네임/프로필 이미지 URL 모두 보내도록 설계(변경하지 않는 정보도 기존 정보로 보내도록)
* API 정보는 Swagger 및 이슈 참고
* 테스트 구현


### Swagger API

*  Swagger 3.0 버전부터 도입된 OpenAPI Specification 사용 (처음 사용해봐서 잘 사용한 건지 모르겠네요 ㅠㅠ)
* Swagger URL : `http://localhost:8080/swagger-ui/index.html`

### 테스트 환경

* `MemberBuilder`로 기본으로 사용하는 default Member 및 build 필드들 생성
* E2E 테스트에서 RestAssured 사용 & 테스트 데이터 롤백을 위해서 `TruncateUtils` 구현
* 현재 Service 테스트에서 `@Transactional`에서 롤백은 정상적으로 되지만, 쿼리문 로깅이 안되는 문제 발생
  * 관련 이슈 #13 



## 💬 리뷰 중점사항

* 내 정보 수정/조회 API & Swagger 구성 작업까지 하나의 PR에 담아서 조금 내용이 많아졌습니다,,
* 계속 approve 받고 merge하면 작업이 늦어질 것 같아서 작업 크기가 커진 점 양해부탁드립니다!!
* 작업 크기가 커서 API 하나씩 보면 좋을 것 같습니다!!
* 잘 이해 안 가시는 부분이 있으면 편하게 코멘트나 연락부탁드립니다!!
