### PR TITLE
장소 추가 기능 & API 구현

### DIFF
--- a/src/main/java/haru/harudongseon/member/presentation/LoginController.java
+++ b/src/main/java/haru/harudongseon/member/presentation/LoginController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "LOGIN API", description = "로그인 API")
 @RestController
 @RequiredArgsConstructor
 public class LoginController {

--- a/src/main/java/haru/harudongseon/member/presentation/MemberController.java
+++ b/src/main/java/haru/harudongseon/member/presentation/MemberController.java
@@ -42,7 +42,7 @@ public class MemberController {
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @ApiResponse(responseCode = "404", description = "멤버 Not Found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
     @PatchMapping("/me")
-    public ResponseEntity<MyProfileResponse> editMyProfile(@Parameter(hidden = true) @AuthPrincipal AuthMemberDto authMemberDto,
+    public ResponseEntity<Void> editMyProfile(@Parameter(hidden = true) @AuthPrincipal AuthMemberDto authMemberDto,
                                                           @Valid @RequestBody MyProfileEditRequest request) {
         memberService.editMyProfile(authMemberDto.memberId(), request);
         return ResponseEntity.ok().build();

--- a/src/main/java/haru/harudongseon/member/presentation/MemberController.java
+++ b/src/main/java/haru/harudongseon/member/presentation/MemberController.java
@@ -39,7 +39,7 @@ public class MemberController {
     }
 
     @Operation(summary = "내 정보 수정 API")
-    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiResponse(responseCode = "200", description = "수정 성공")
     @ApiResponse(responseCode = "404", description = "멤버 Not Found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
     @PatchMapping("/me")
     public ResponseEntity<Void> editMyProfile(@Parameter(hidden = true) @AuthPrincipal AuthMemberDto authMemberDto,

--- a/src/main/java/haru/harudongseon/place/application/PlaceService.java
+++ b/src/main/java/haru/harudongseon/place/application/PlaceService.java
@@ -1,0 +1,32 @@
+package haru.harudongseon.place.application;
+
+import java.util.Optional;
+
+import haru.harudongseon.place.application.dto.PlaceAddRequest;
+import haru.harudongseon.place.domain.Place;
+import haru.harudongseon.place.domain.PlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PlaceService {
+
+    private final PlaceRepository placeRepository;
+
+    public void addPlace(final PlaceAddRequest request) {
+        final Optional<Place> optionalPlace = placeRepository.findByProviderPlaceId(request.providerPlaceId());
+        if (optionalPlace.isPresent()) {
+            final Place place = optionalPlace.get();
+            place.select();
+        }
+
+        if (optionalPlace.isEmpty()) {
+            final Place place = new Place(request.providerPlaceId(), request.name(), request.category(),
+                    request.latitude(), request.longitude(), request.addressName());
+            placeRepository.save(place);
+        }
+    }
+}

--- a/src/main/java/haru/harudongseon/place/application/dto/PlaceAddRequest.java
+++ b/src/main/java/haru/harudongseon/place/application/dto/PlaceAddRequest.java
@@ -1,0 +1,29 @@
+package haru.harudongseon.place.application.dto;
+
+import java.math.BigDecimal;
+
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotBlank;
+
+public record PlaceAddRequest(
+        @NotBlank(message = "외부 제공자의 장소 ID는 공백일 수 없습니다.")
+        Long providerPlaceId,
+
+        @NotBlank(message = "장소 이름은 공백일 수 없습니다.")
+        String name,
+
+        @NotBlank(message = "카테고리는 공백일 수 없습니다.")
+        String category,
+
+        @NotBlank(message = "위도는 공백일 수 없습니다.")
+        @Digits(message = "위도는 10진수 9자, 소수점 6자 이내 여야합니다.", integer = 9, fraction = 6)
+        BigDecimal latitude,
+
+        @NotBlank(message = "경도는 공백일 수 없습니다.")
+        @Digits(message = "경도는 10진수 9자, 소수점 6자 이내 여야합니다.", integer = 9, fraction = 6)
+        BigDecimal longitude,
+
+        @NotBlank(message = "주소 이름은 공백일 수 없습니다.")
+        String addressName
+) {
+}

--- a/src/main/java/haru/harudongseon/place/application/dto/PlaceAddRequest.java
+++ b/src/main/java/haru/harudongseon/place/application/dto/PlaceAddRequest.java
@@ -2,28 +2,37 @@ package haru.harudongseon.place.application.dto;
 
 import java.math.BigDecimal;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record PlaceAddRequest(
-        @NotBlank(message = "외부 제공자의 장소 ID는 공백일 수 없습니다.")
+
+        @NotNull(message = "외부 제공자의 장소 ID는 공백일 수 없습니다.")
+        @Schema(description = "외부 제공자 장소 ID(카카오 장소 ID)", nullable = false, example = "16618597")
         Long providerPlaceId,
 
         @NotBlank(message = "장소 이름은 공백일 수 없습니다.")
+        @Schema(description = "장소 이름", nullable = false, example = "장생당약국")
         String name,
 
         @NotBlank(message = "카테고리는 공백일 수 없습니다.")
+        @Schema(description = "장소 카테고리", nullable = false, example = "약국")
         String category,
 
-        @NotBlank(message = "위도는 공백일 수 없습니다.")
+        @NotNull(message = "위도는 공백일 수 없습니다. 올바른 형식 또는 값을 입력해주세요.")
         @Digits(message = "위도는 10진수 9자, 소수점 6자 이내 여야합니다.", integer = 9, fraction = 6)
+        @Schema(description = "장소 위도(10진수 9자, 소수점 6자 이내)", nullable = false, example = "127.058970")
         BigDecimal latitude,
 
-        @NotBlank(message = "경도는 공백일 수 없습니다.")
+        @NotNull(message = "경도는 공백일 수 없습니다. 올바른 형식 또는 값을 입력해주세요.")
         @Digits(message = "경도는 10진수 9자, 소수점 6자 이내 여야합니다.", integer = 9, fraction = 6)
+        @Schema(description = "장소 경도(10진수 9자, 소수점 6자 이내)", nullable = false, example = "37.506051")
         BigDecimal longitude,
 
         @NotBlank(message = "주소 이름은 공백일 수 없습니다.")
+        @Schema(description = "장소 주소 이름", nullable = false, example = "서울 대치동")
         String addressName
 ) {
 }

--- a/src/main/java/haru/harudongseon/place/domain/Coordinates.java
+++ b/src/main/java/haru/harudongseon/place/domain/Coordinates.java
@@ -1,0 +1,22 @@
+package haru.harudongseon.place.domain;
+
+import java.math.BigDecimal;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Coordinates {
+
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+
+    public Coordinates(final BigDecimal latitude, final BigDecimal longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/src/main/java/haru/harudongseon/place/domain/Place.java
+++ b/src/main/java/haru/harudongseon/place/domain/Place.java
@@ -1,0 +1,44 @@
+package haru.harudongseon.place.domain;
+
+import java.math.BigDecimal;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Place {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long providerPlaceId;
+
+    private String name;
+
+    private String category;
+
+    @Embedded
+    private Coordinates coordinates;
+
+    private String addressName;
+    private int selectCount;
+
+    public Place(final Long providerPlaceId, final String name,
+                 final String category, final BigDecimal latitude,
+                 final BigDecimal longitude, final String addressName) {
+        this.providerPlaceId = providerPlaceId;
+        this.name = name;
+        this.category = category;
+        this.coordinates = new Coordinates(latitude, longitude);
+        this.addressName = addressName;
+        this.selectCount = 0;
+    }
+
+    public void select() {
+        this.selectCount++;
+    }
+}

--- a/src/main/java/haru/harudongseon/place/domain/PlaceRepository.java
+++ b/src/main/java/haru/harudongseon/place/domain/PlaceRepository.java
@@ -1,0 +1,10 @@
+package haru.harudongseon.place.domain;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+
+    Optional<Place> findByProviderPlaceId(final Long providerPlaceId);
+}

--- a/src/main/java/haru/harudongseon/place/presentation/PlaceController.java
+++ b/src/main/java/haru/harudongseon/place/presentation/PlaceController.java
@@ -1,0 +1,35 @@
+package haru.harudongseon.place.presentation;
+
+import haru.harudongseon.place.application.PlaceService;
+import haru.harudongseon.place.application.dto.PlaceAddRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "PLACE API", description = "장소 관련 API")
+@RestController
+@RequestMapping("/places")
+@RequiredArgsConstructor
+public class PlaceController {
+
+    private final PlaceService placeService;
+
+    @Operation(summary = "장소 추가 API")
+    @ApiResponse(responseCode = "200", description = "장소 추가 성공")
+    @ApiResponse(responseCode = "400", description = "요청 Field Error", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+    @PostMapping
+    public ResponseEntity<Void> addPlace(@RequestBody @Valid final PlaceAddRequest request) {
+        placeService.addPlace(request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/test/java/haru/harudongseon/common/E2ETest.java
+++ b/src/test/java/haru/harudongseon/common/E2ETest.java
@@ -1,0 +1,18 @@
+package haru.harudongseon.common;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public abstract class E2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+}

--- a/src/test/java/haru/harudongseon/common/E2ETest.java
+++ b/src/test/java/haru/harudongseon/common/E2ETest.java
@@ -1,18 +1,30 @@
 package haru.harudongseon.common;
 
+import haru.harudongseon.global.jwt.JwtService;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public abstract class E2ETest {
 
+    protected static final String JWT_PREFIX = "Bearer ";
+
+    @Autowired
+    private H2TruncateUtils h2TruncateUtils;
+
+    @Autowired
+    protected JwtService jwtService;
+
     @LocalServerPort
     private int port;
 
     @BeforeEach
     void setUp() {
-        RestAssured.port = port;
+        RestAssured.port = this.port;
+        h2TruncateUtils.truncateAll();
     }
+
 }

--- a/src/test/java/haru/harudongseon/common/ServiceTest.java
+++ b/src/test/java/haru/harudongseon/common/ServiceTest.java
@@ -1,0 +1,9 @@
+package haru.harudongseon.common;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+public abstract class ServiceTest {
+}

--- a/src/test/java/haru/harudongseon/common/builder/MemberBuilder.java
+++ b/src/test/java/haru/harudongseon/common/builder/MemberBuilder.java
@@ -1,6 +1,6 @@
 package haru.harudongseon.common.builder;
 
-import static haru.harudongseon.common.fixtures.member.MemberFixtures.*;
+import static haru.harudongseon.common.fixtures.MemberFixtures.*;
 
 import haru.harudongseon.global.oauth.LoginType;
 import haru.harudongseon.member.domain.Member;

--- a/src/test/java/haru/harudongseon/common/builder/MemberBuilder.java
+++ b/src/test/java/haru/harudongseon/common/builder/MemberBuilder.java
@@ -22,12 +22,12 @@ public class MemberBuilder {
     private LoginType loginType;
 
     public MemberBuilder defaultMember() {
-        this.email = 성하_이메일;
-        this.nickname = 성하_닉네임;
-        this.profileImageUrl = 성하_프로필_이미지_URL;
-        this.oauthId = 성하_OAUTH_ID;
-        this.deviceId = 성하_DEVICE_ID;
-        this.loginType = 성하_LOGIN_TYPE;
+        this.email = 기본_이메일;
+        this.nickname = 기본_닉네임;
+        this.profileImageUrl = 기본_프로필_이미지_URL;
+        this.oauthId = 기본_OAUTH_ID;
+        this.deviceId = 기본_DEVICE_ID;
+        this.loginType = 기본_LOGIN_TYPE;
 
         return this;
     }

--- a/src/test/java/haru/harudongseon/common/builder/PlaceBuilder.java
+++ b/src/test/java/haru/harudongseon/common/builder/PlaceBuilder.java
@@ -4,6 +4,7 @@ import static haru.harudongseon.common.fixtures.PlaceFixtures.*;
 
 import java.math.BigDecimal;
 
+import haru.harudongseon.place.application.dto.PlaceAddRequest;
 import haru.harudongseon.place.domain.Place;
 import haru.harudongseon.place.domain.PlaceRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,5 +67,16 @@ public class PlaceBuilder {
     public Place build() {
         final Place place = new Place(providerPlaceId, name, category, latitude, longitude, addressName);
         return placeRepository.save(place);
+    }
+
+    public PlaceAddRequest buildPlaceAddRequest(final Place place) {
+        return new PlaceAddRequest(
+                place.getProviderPlaceId(),
+                place.getName(),
+                place.getCategory(),
+                place.getCoordinates().getLatitude(),
+                place.getCoordinates().getLongitude(),
+                place.getAddressName()
+        );
     }
 }

--- a/src/test/java/haru/harudongseon/common/builder/PlaceBuilder.java
+++ b/src/test/java/haru/harudongseon/common/builder/PlaceBuilder.java
@@ -1,0 +1,70 @@
+package haru.harudongseon.common.builder;
+
+import static haru.harudongseon.common.fixtures.PlaceFixtures.*;
+
+import java.math.BigDecimal;
+
+import haru.harudongseon.place.domain.Place;
+import haru.harudongseon.place.domain.PlaceRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PlaceBuilder {
+
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    private Long providerPlaceId;
+    private String name;
+    private String category;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+    private String addressName;
+
+    public PlaceBuilder defaultPlace() {
+        this.providerPlaceId = 기본_외부_공급자_ID;
+        this.name = 기본_장소_이름;
+        this.category = 기본_장소_카테고리;
+        this.latitude = 기본_장소_위도;
+        this.longitude = 기본_장소_경도;
+        this.addressName = 기본_장소_주소_이름;
+
+        return this;
+    }
+
+    public PlaceBuilder providerPlaceId(final Long providerPlaceId) {
+        this.providerPlaceId = providerPlaceId;
+        return this;
+    }
+
+    public PlaceBuilder name(final String name) {
+        this.name = name;
+        return this;
+    }
+
+    public PlaceBuilder category(final String category) {
+        this.category = category;
+        return this;
+    }
+
+    public PlaceBuilder latitude(final BigDecimal latitude) {
+        this.latitude = latitude;
+        return this;
+    }
+
+    public PlaceBuilder longitude(final BigDecimal longitude) {
+        this.longitude = longitude;
+        return this;
+    }
+
+    public PlaceBuilder addressName(final String addressName) {
+        this.addressName = addressName;
+        return this;
+    }
+
+    public Place build() {
+        final Place place = new Place(providerPlaceId, name, category, latitude, longitude, addressName);
+        return placeRepository.save(place);
+    }
+}

--- a/src/test/java/haru/harudongseon/common/fixtures/MemberFixtures.java
+++ b/src/test/java/haru/harudongseon/common/fixtures/MemberFixtures.java
@@ -5,13 +5,12 @@ import haru.harudongseon.global.oauth.LoginType;
 public class MemberFixtures {
 
     /**
-     * 멤버 1 (성하)
+     * 기본 멤버 (성하)
      */
-    public static final String 성하_이메일 = "seongha@gmail.com";
-    public static final String 성하_닉네임 = "SEONGHA";
-    public static final String 성하_프로필_이미지_URL = "https://lh3.googleusercontent.com/a/xxx";
-    public static final String 성하_OAUTH_ID = "a12345";
-    public static final String 성하_DEVICE_ID = "abc1234";
-    public static final LoginType 성하_LOGIN_TYPE = LoginType.NAVER;
-
+    public static final String 기본_이메일 = "seongha@gmail.com";
+    public static final String 기본_닉네임 = "SEONGHA";
+    public static final String 기본_프로필_이미지_URL = "https://lh3.googleusercontent.com/a/xxx";
+    public static final String 기본_OAUTH_ID = "a12345";
+    public static final String 기본_DEVICE_ID = "abc1234";
+    public static final LoginType 기본_LOGIN_TYPE = LoginType.NAVER;
 }

--- a/src/test/java/haru/harudongseon/common/fixtures/MemberFixtures.java
+++ b/src/test/java/haru/harudongseon/common/fixtures/MemberFixtures.java
@@ -1,4 +1,4 @@
-package haru.harudongseon.common.fixtures.member;
+package haru.harudongseon.common.fixtures;
 
 import haru.harudongseon.global.oauth.LoginType;
 

--- a/src/test/java/haru/harudongseon/common/fixtures/PlaceFixtures.java
+++ b/src/test/java/haru/harudongseon/common/fixtures/PlaceFixtures.java
@@ -2,6 +2,7 @@ package haru.harudongseon.common.fixtures;
 
 import java.math.BigDecimal;
 
+import haru.harudongseon.place.application.dto.PlaceAddRequest;
 import haru.harudongseon.place.domain.Place;
 
 public class PlaceFixtures {
@@ -13,7 +14,11 @@ public class PlaceFixtures {
     public static final BigDecimal 기본_장소_경도 = new BigDecimal("37.506051");
     public static final String 기본_장소_주소_이름 = "서울 대치동";
 
+
     public static Place 기본_장소_Entity() {
         return new Place(기본_외부_공급자_ID, 기본_장소_이름, 기본_장소_카테고리, 기본_장소_위도, 기본_장소_경도, 기본_장소_주소_이름);
     }
+
+    public static final PlaceAddRequest 기본_장소_추가_REQUEST =
+            new PlaceAddRequest(기본_외부_공급자_ID, 기본_장소_이름, 기본_장소_카테고리, 기본_장소_위도, 기본_장소_경도, 기본_장소_주소_이름);
 }

--- a/src/test/java/haru/harudongseon/common/fixtures/PlaceFixtures.java
+++ b/src/test/java/haru/harudongseon/common/fixtures/PlaceFixtures.java
@@ -1,0 +1,19 @@
+package haru.harudongseon.common.fixtures;
+
+import java.math.BigDecimal;
+
+import haru.harudongseon.place.domain.Place;
+
+public class PlaceFixtures {
+
+    public static final Long 기본_외부_공급자_ID = 16618597L;
+    public static final String 기본_장소_이름 = "장생당약국";
+    public static final String 기본_장소_카테고리 = "약국";
+    public static final BigDecimal 기본_장소_위도 = new BigDecimal("127.058970");
+    public static final BigDecimal 기본_장소_경도 = new BigDecimal("37.506051");
+    public static final String 기본_장소_주소_이름 = "서울 대치동";
+
+    public static Place 기본_장소_Entity() {
+        return new Place(기본_외부_공급자_ID, 기본_장소_이름, 기본_장소_카테고리, 기본_장소_위도, 기본_장소_경도, 기본_장소_주소_이름);
+    }
+}

--- a/src/test/java/haru/harudongseon/member/application/MemberServiceTest.java
+++ b/src/test/java/haru/harudongseon/member/application/MemberServiceTest.java
@@ -3,6 +3,7 @@ package haru.harudongseon.member.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import haru.harudongseon.common.ServiceTest;
 import haru.harudongseon.common.builder.MemberBuilder;
 import haru.harudongseon.member.application.dto.MyProfileEditRequest;
 import haru.harudongseon.member.application.dto.MyProfileResponse;
@@ -13,12 +14,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@Transactional
-public class MemberServiceTest {
+public class MemberServiceTest extends ServiceTest {
 
     @Autowired
     private MemberService memberService;

--- a/src/test/java/haru/harudongseon/member/presentation/MemberControllerTest.java
+++ b/src/test/java/haru/harudongseon/member/presentation/MemberControllerTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.util.stream.Stream;
 
+import haru.harudongseon.common.E2ETest;
 import haru.harudongseon.common.H2TruncateUtils;
 import haru.harudongseon.common.builder.MemberBuilder;
 import haru.harudongseon.common.fixtures.member.MemberFixtures;
@@ -16,7 +17,6 @@ import io.restassured.RestAssured;
 import io.restassured.path.json.JsonPath;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -27,15 +27,13 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class MemberControllerTest {
-    
+class MemberControllerTest extends E2ETest {
+
     private static final String JWT_PREFIX = "Bearer ";
 
     @LocalServerPort
@@ -46,7 +44,7 @@ class MemberControllerTest {
 
     @Autowired
     private MemberBuilder memberBuilder;
-    
+
     @Autowired
     private JwtService jwtService;
 

--- a/src/test/java/haru/harudongseon/member/presentation/MemberControllerTest.java
+++ b/src/test/java/haru/harudongseon/member/presentation/MemberControllerTest.java
@@ -1,6 +1,6 @@
 package haru.harudongseon.member.presentation;
 
-import static haru.harudongseon.common.fixtures.member.MemberFixtures.성하_프로필_이미지_URL;
+import static haru.harudongseon.common.fixtures.MemberFixtures.성하_프로필_이미지_URL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
@@ -9,7 +9,7 @@ import java.util.stream.Stream;
 import haru.harudongseon.common.E2ETest;
 import haru.harudongseon.common.H2TruncateUtils;
 import haru.harudongseon.common.builder.MemberBuilder;
-import haru.harudongseon.common.fixtures.member.MemberFixtures;
+import haru.harudongseon.common.fixtures.MemberFixtures;
 import haru.harudongseon.global.jwt.JwtService;
 import haru.harudongseon.member.application.dto.MyProfileEditRequest;
 import haru.harudongseon.member.domain.Member;

--- a/src/test/java/haru/harudongseon/member/presentation/MemberControllerTest.java
+++ b/src/test/java/haru/harudongseon/member/presentation/MemberControllerTest.java
@@ -7,7 +7,6 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import java.util.stream.Stream;
 
 import haru.harudongseon.common.E2ETest;
-import haru.harudongseon.common.H2TruncateUtils;
 import haru.harudongseon.common.builder.MemberBuilder;
 import haru.harudongseon.common.fixtures.MemberFixtures;
 import haru.harudongseon.global.jwt.JwtService;
@@ -17,7 +16,6 @@ import io.restassured.RestAssured;
 import io.restassured.path.json.JsonPath;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -27,32 +25,14 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 class MemberControllerTest extends E2ETest {
 
-    private static final String JWT_PREFIX = "Bearer ";
-
-    @LocalServerPort
-    private int port;
-
-    @Autowired
-    private H2TruncateUtils h2TruncateUtils;
-
     @Autowired
     private MemberBuilder memberBuilder;
-
-    @Autowired
-    private JwtService jwtService;
-
-    @BeforeEach
-    void setUp() {
-        RestAssured.port = this.port;
-        h2TruncateUtils.truncateAll();
-    }
 
     @Nested
     @DisplayName("내 정보 조회 시")

--- a/src/test/java/haru/harudongseon/member/presentation/MemberControllerTest.java
+++ b/src/test/java/haru/harudongseon/member/presentation/MemberControllerTest.java
@@ -1,6 +1,6 @@
 package haru.harudongseon.member.presentation;
 
-import static haru.harudongseon.common.fixtures.MemberFixtures.성하_프로필_이미지_URL;
+import static haru.harudongseon.common.fixtures.MemberFixtures.기본_프로필_이미지_URL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
@@ -121,8 +121,8 @@ class MemberControllerTest extends E2ETest {
         }
 
         private static Stream<Arguments> editRequests() {
-            final String nickname = MemberFixtures.성하_닉네임;
-            final String profileImageUrl = 성하_프로필_이미지_URL;
+            final String nickname = MemberFixtures.기본_닉네임;
+            final String profileImageUrl = 기본_프로필_이미지_URL;
 
             return Stream.of(
                     Arguments.arguments(new MyProfileEditRequest(nickname, profileImageUrl)),
@@ -138,7 +138,7 @@ class MemberControllerTest extends E2ETest {
             // given
             final Long notExistMemberId = -1L;
             final String accessToken = jwtService.createAccessToken(notExistMemberId);
-            final MyProfileEditRequest request = new MyProfileEditRequest("seongha1", 성하_프로필_이미지_URL);
+            final MyProfileEditRequest request = new MyProfileEditRequest("seongha1", 기본_프로필_이미지_URL);
 
             // when
             final ExtractableResponse<Response> response = EDIT_MY_PROFILE_REQUEST(accessToken, request);

--- a/src/test/java/haru/harudongseon/place/application/PlaceServiceTest.java
+++ b/src/test/java/haru/harudongseon/place/application/PlaceServiceTest.java
@@ -1,0 +1,90 @@
+package haru.harudongseon.place.application;
+
+import static haru.harudongseon.common.fixtures.PlaceFixtures.*;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.junit.jupiter.api.Assertions.*;
+
+import haru.harudongseon.common.ServiceTest;
+import haru.harudongseon.common.builder.PlaceBuilder;
+import haru.harudongseon.common.fixtures.PlaceFixtures;
+import haru.harudongseon.place.application.dto.PlaceAddRequest;
+import haru.harudongseon.place.domain.Place;
+import haru.harudongseon.place.domain.PlaceRepository;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class PlaceServiceTest extends ServiceTest {
+
+    @Autowired
+    private PlaceService placeService;
+
+    @Autowired
+    private PlaceBuilder placeBuilder;
+
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    @Nested
+    @DisplayName("장소 추가 시")
+    class AddPlace {
+
+        @Test
+        @DisplayName("기존에 장소가 없을 때는 장소가 추가된다.")
+        void success_not_exist_place_add_place() {
+            // given
+            final Long providerPlaceId = 기본_외부_공급자_ID;
+            final PlaceAddRequest request = new PlaceAddRequest(providerPlaceId,
+                                                                기본_장소_이름,
+                                                                기본_장소_카테고리,
+                                                                기본_장소_위도,
+                                                                기본_장소_경도,
+                                                                기본_장소_주소_이름);
+            final long countBeforeAdd = placeRepository.count();
+            final Place expected = 기본_장소_Entity();
+
+            // when
+            placeService.addPlace(request);
+            final long countAfterAdd = placeRepository.count();
+            final Place actual = placeRepository.findByProviderPlaceId(providerPlaceId).get();
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(countBeforeAdd).isEqualTo(0);
+                softly.assertThat(countAfterAdd).isEqualTo(1);
+                softly.assertThat(actual).usingRecursiveComparison()
+                        .ignoringFields("id")
+                        .isEqualTo(expected);
+            });
+        }
+
+        @Test
+        @DisplayName("기존에 장소가 있을 때는 기존 장소에 선택 카운트가 1 증가한다.")
+        void success_exist_place_select_count_1_increase() {
+            // given
+            final Place expected = placeBuilder.defaultPlace().build();
+            final Long providerPlaceId = 기본_외부_공급자_ID;
+            final PlaceAddRequest request = new PlaceAddRequest(providerPlaceId,
+                                                                기본_장소_이름,
+                                                                기본_장소_카테고리,
+                                                                기본_장소_위도,
+                                                                기본_장소_경도,
+                                                                기본_장소_주소_이름);
+            final int beforeSelectCount = expected.getSelectCount();
+
+            // when
+            placeService.addPlace(request);
+            final Place actual = placeRepository.findByProviderPlaceId(providerPlaceId).get();
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(actual.getSelectCount()).isEqualTo(beforeSelectCount + 1);
+                softly.assertThat(actual).usingRecursiveComparison()
+                        .ignoringFields("selectCount")
+                        .isEqualTo(expected);
+            });
+        }
+    }
+}

--- a/src/test/java/haru/harudongseon/place/presentation/PlaceControllerTest.java
+++ b/src/test/java/haru/harudongseon/place/presentation/PlaceControllerTest.java
@@ -1,0 +1,154 @@
+package haru.harudongseon.place.presentation;
+
+import static haru.harudongseon.common.fixtures.PlaceFixtures.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.math.BigDecimal;
+import java.util.stream.Stream;
+
+import haru.harudongseon.common.E2ETest;
+import haru.harudongseon.common.builder.MemberBuilder;
+import haru.harudongseon.common.builder.PlaceBuilder;
+import haru.harudongseon.member.domain.Member;
+import haru.harudongseon.place.application.dto.PlaceAddRequest;
+import haru.harudongseon.place.domain.Place;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+class PlaceControllerTest extends E2ETest {
+
+    @Autowired
+    private MemberBuilder memberBuilder;
+
+    @Autowired
+    private PlaceBuilder placeBuilder;
+
+    @Nested
+    @DisplayName("장소 추가 시 ")
+    class AddPlace {
+
+        @Test
+        @DisplayName("존재하지 않는 장소면, 장소를 추가한다.")
+        void success_not_exist_place_add_place() {
+            // given
+            final Member member = memberBuilder.defaultMember().build();
+            final String accessToken = jwtService.createAccessToken(member.getId());
+            final PlaceAddRequest notExistPlaceRequest = 기본_장소_추가_REQUEST;
+
+            // when
+            final ExtractableResponse<Response> response = ADD_PLACE_REQUEST(accessToken, notExistPlaceRequest);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        }
+
+        @Test
+        @DisplayName("이미 장소가 존재한다면, 장소의 선택 횟수를 1 증가시킨다.")
+        void success_exist_place_select_count_1_increase() {
+            // given
+            final Member member = memberBuilder.defaultMember().build();
+            final String accessToken = jwtService.createAccessToken(member.getId());
+            final Place place = placeBuilder.defaultPlace().build();
+            final PlaceAddRequest existPlaceRequest = placeBuilder.buildPlaceAddRequest(place);
+
+            // when
+            final ExtractableResponse<Response> response = ADD_PLACE_REQUEST(accessToken, existPlaceRequest);
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        }
+
+        @ParameterizedTest
+        @MethodSource(value = "failNullRequests")
+        @DisplayName("장소 정보 중에 하나라도 값이 없으면 장소 추가에 실패한다.")
+        void fail_place_request_field_null(final PlaceAddRequest request) {
+            // given
+            final Member member = memberBuilder.defaultMember().build();
+            final String accessToken = jwtService.createAccessToken(member.getId());
+
+            // when
+            final ExtractableResponse<Response> response = ADD_PLACE_REQUEST(accessToken, request);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+                softly.assertThat(response.jsonPath().getString("errorMessage")).contains("공백일 수 없습니다.");
+            });
+        }
+
+        private static Stream<Arguments> failNullRequests() {
+            final Long providerPlaceId = 기본_외부_공급자_ID;
+            final String name = 기본_장소_이름;
+            final String category = 기본_장소_카테고리;
+            final BigDecimal latitude = 기본_장소_위도;
+            final BigDecimal longitude = 기본_장소_경도;
+            final String addressName = 기본_장소_주소_이름;
+
+            return Stream.of(
+                    Arguments.arguments(new PlaceAddRequest(null, name, category, latitude, longitude, addressName)),
+                    Arguments.arguments(new PlaceAddRequest(providerPlaceId, null, category, latitude, longitude, addressName)),
+                    Arguments.arguments(new PlaceAddRequest(providerPlaceId, name, null, latitude, longitude, addressName)),
+                    Arguments.arguments(new PlaceAddRequest(providerPlaceId, name, category, null, longitude, addressName)),
+                    Arguments.arguments(new PlaceAddRequest(providerPlaceId, name, category, latitude, null, addressName)),
+                    Arguments.arguments(new PlaceAddRequest(providerPlaceId, name, category, latitude, longitude, null))
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource(value = "failCoordinateWrongValidationRequests")
+        @DisplayName("장소의 위도, 경도가 올바른 형식이 아니면 장소 추가에 실패한다.")
+        void fail_place_coordinates_wrong_validation(final PlaceAddRequest request) {
+            // given
+            final Member member = memberBuilder.defaultMember().build();
+            final String accessToken = jwtService.createAccessToken(member.getId());
+
+            // when
+            final ExtractableResponse<Response> response = ADD_PLACE_REQUEST(accessToken, request);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+                softly.assertThat(response.jsonPath().getString("errorMessage")).contains("10진수 9자, 소수점 6자 이내 여야합니다.");
+            });
+        }
+
+        private static Stream<Arguments> failCoordinateWrongValidationRequests() {
+            final Long providerPlaceId = 기본_외부_공급자_ID;
+            final String name = 기본_장소_이름;
+            final String category = 기본_장소_카테고리;
+            final BigDecimal latitude = 기본_장소_위도;
+            final BigDecimal longitude = 기본_장소_경도;
+            final String addressName = 기본_장소_주소_이름;
+
+            return Stream.of(
+                    Arguments.arguments(new PlaceAddRequest(providerPlaceId, name, category, new BigDecimal(1234567890.0), longitude, addressName)),
+                    Arguments.arguments(new PlaceAddRequest(providerPlaceId, name, category, latitude, new BigDecimal(1234567890.0), addressName)),
+                    Arguments.arguments(new PlaceAddRequest(providerPlaceId, name, category, new BigDecimal(1.1234567), longitude, addressName)),
+                    Arguments.arguments(new PlaceAddRequest(providerPlaceId, name, category, latitude, new BigDecimal(1.1234567), addressName))
+            );
+        }
+    }
+
+    private static ExtractableResponse<Response> ADD_PLACE_REQUEST(final String accessToken, final PlaceAddRequest request) {
+        return RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, JWT_PREFIX + accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when().log().all()
+                .post("/places")
+                .then().log().all()
+                .extract();
+    }
+}


### PR DESCRIPTION
## 🔥 연관 이슈

- close #19 

## 🚀 작업 내용

### 장소 추가 기능 & API 구현

* 장소 추가 기능 로직
  * 추가하는 장소가 DB에 없다면, DB에 추가
  * DB에 있다면, 선택 Count + 1

* 장소 위도/경도 Validation 
  * 10진수 9자리 이내 & 소수점 이하 6자리 이내

* 요청 시 providerPlaceId (제공받은 장소의 식별자)
  * 외부에서 제공받은 장소의 식별자를 그대로 사용
  * 장소 추가 시에는 프론트에서 외부에서 검색한 장소를 요청하기 때문에 DB에서 장소 존재 여부를 PK로 식별할 수 없음.
  * 따라서 외부의 장소 제공자(ex : 카카오, 구글 등)의 식별자를 받아서 DB에 이미 존재하는지 확인


## 💬 리뷰 중점사항
